### PR TITLE
updateCamaeraClass

### DIFF
--- a/Hide/Camera.cpp
+++ b/Hide/Camera.cpp
@@ -8,10 +8,6 @@ void Camera::move(int, int)
 {
 }
 
-void Camera::change()
-{
-}
-
 bool Camera::get()
 {
 	return false;

--- a/Hide/Camera.h
+++ b/Hide/Camera.h
@@ -1,16 +1,17 @@
 #pragma once
 #include"DxLib.h"
+#include"Point.h"
 
 class Camera {
 public:
 	//Camera();
 	void update();
 	void move(int, int);
-	void change();
+	//void change();
 	bool get();
 private:
-	RECT range;
+	Point range;
 	bool mode;//enumで用意する可能性あり
-	int prex;//移動前の座標
-	int prey;
+	int preX;//移動前の座標
+	int preY;
 };


### PR DESCRIPTION
カメラクラス更新Classリストから消えていたchangeメソッドの削除（コメントアウトしているだけなので必要に応じて解除してください）