### PR TITLE
Rendering処理の大幅刷新！

### DIFF
--- a/Hide/CoreTask.cpp
+++ b/Hide/CoreTask.cpp
@@ -1,4 +1,4 @@
-#include "CoreTask.h"
+﻿#include "CoreTask.h"
 
 GameTaskSystem *gts;
 

--- a/Hide/CoreTask.cpp
+++ b/Hide/CoreTask.cpp
@@ -4,13 +4,13 @@ GameTaskSystem *gts;
 
 CoreTask::CoreTask()
 {
+	graph = std::make_unique<GraphicResource>();
 	scene = Scene::title;//–{“–‚Í^Cg‹
 	tts = std::make_unique<TitleTaskSystem>();
 	gts = std::make_unique<GameTaskSystem>();
 	ssts = std::make_unique<StageSelectTaskSystem>();
 	keyboard = std::make_unique<Keyboard>();
 	cts = std::make_unique<ClearTaskSystem>();
-	graph = std::make_unique<GraphicResource>();
 	gots = std::make_unique<GameOverTaskSystem>();
 }
 
@@ -25,6 +25,7 @@ void CoreTask::update()
 		ssts->update();
 		break;
 	case Scene::game:
+		//graph->load("player");
 		gts->update();
 		break;
 	case Scene::gameover:

--- a/Hide/CoreTask.h
+++ b/Hide/CoreTask.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include<memory>
 #include"GameTaskSystem.h"
 #include"TitleTaskSystem.h"

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -4,6 +4,8 @@
 GameTaskSystem::GameTaskSystem()
 {
 	normalstar = std::make_shared<BasicList<NormalStar>>();
+	map = std::make_unique<Map>();
+	player = std::make_unique<Player>();
 }
 
 GameTaskSystem::~GameTaskSystem()

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -14,8 +14,8 @@ public:
 	~GameTaskSystem();
 	void update();
 	//~GameTaskSystem();
-	std::unique_ptr<Player> player = std::make_unique<Player>();
-	std::unique_ptr<Map> map = std::make_unique<Map>();
+	std::unique_ptr<Player> player;
+	std::unique_ptr<Map> map;
 	std::shared_ptr<BasicList<NormalStar>> normalstar;
 };
 

--- a/Hide/GraphicResource.cpp
+++ b/Hide/GraphicResource.cpp
@@ -6,7 +6,6 @@
 #include <iterator>
 #include "json11.hpp"
 
-//インストラクタ
 GraphicResource::GraphicResource()
 {
 	std::ifstream ifs("img/resource.json");
@@ -18,13 +17,14 @@ GraphicResource::GraphicResource()
 	std::istreambuf_iterator<char> last;
 	std::string json_str(it, last);		//string形式のjson
 	std::string err;
-	auto json = json11::Json::parse(json_str,err);	//json11で利用できる形式に変換
-	auto foo = json["graph"];
+	json = json11::Json::parse(json_str,err);	//json11で利用できる形式に変換
 	int count_of_graph = 0;
 	for (auto &item : json["graph"].array_items()) {
 		//画像の枚数を数える
 		count_of_graph++;
 	}
+
+	//下記の処理はload()へ移動予定
 	graph = std::make_unique<GraphicObject[]>(count_of_graph);	//画像の枚数分の領域を確保する
 	int i = 0;
 	for (auto &item : json["graph"].array_items()) {
@@ -43,6 +43,7 @@ GraphicResource::GraphicResource()
 //		slide = item["max"].number_value();
 		i++;
 	}
+
 }
 //デストラクタ
 GraphicResource::~GraphicResource()
@@ -56,6 +57,8 @@ bool GraphicResource::load(std::string scope)
 	//scopeの文字列の画像をjsonから検索し、読み込む
 	//失敗すれば0、成功すれば0以外を返す
 	//処理は未実装
+	for (auto &item : json["graph"].array_items()) {
+	}
 	return true;
 }
 

--- a/Hide/GraphicResource.cpp
+++ b/Hide/GraphicResource.cpp
@@ -78,7 +78,10 @@ bool GraphicResource::load(std::string _scope)
 
 GraphicObject GraphicResource::get(std::string name)
 {
-	return graph[get_index(name)];
+	int index = get_index(name);
+	GraphicObject ret;
+	if (index != -1) ret = graph[index];
+	return ret;
 }
 
 void GraphicResource::register_graph(json11::Json item)

--- a/Hide/GraphicResource.cpp
+++ b/Hide/GraphicResource.cpp
@@ -18,31 +18,33 @@ GraphicResource::GraphicResource()
 	std::string json_str(it, last);		//string形式のjson
 	std::string err;
 	json = json11::Json::parse(json_str,err);	//json11で利用できる形式に変換
-	int count_of_graph = 0;
 	for (auto &item : json["graph"].array_items()) {
 		//画像の枚数を数える
 		count_of_graph++;
 	}
-
-	//下記の処理はload()へ移動予定
 	graph = std::make_unique<GraphicObject[]>(count_of_graph);	//画像の枚数分の領域を確保する
-	int i = 0;
-	for (auto &item : json["graph"].array_items()) {
-		graph[i].handle = new int[count_of_graph];	//アニメーション画像のフレーム枚数分のハンドル領域を確保する
-		LoadDivGraph(
-			item["path"].string_value().c_str(),
-			item["column"].int_value() * item["line"].int_value(),
-			item["column"].int_value(),
-			item["line"].int_value(), 
-			item["width"].int_value(), 
-			item["height"].int_value(),
-			graph[i].handle
-		);		//JSONに書かれた情報をLoadDivGraphから読み込む
-		graph[i].name = item["name"].string_value();	//JSONで指定された"name"はget()の引数に文字列として指定が可能
-		graph[i].max = item["line"].int_value()*item["column"].int_value();
-//		slide = item["max"].number_value();
-		i++;
-	}
+	for (int i = 0; i < count_of_graph; i++) graph[i].exist = false;
+
+//	//下記の処理はload()へ移動予定  <- 済み
+
+//	int i = 0;
+//	for (auto &item : json["graph"].array_items()) {
+//		graph[i].handle = new int[count_of_graph];	//アニメーション画像のフレーム枚数分のハンドル領域を確保する
+//		LoadDivGraph(
+//			item["path"].string_value().c_str(),
+//			item["column"].int_value() * item["line"].int_value(),
+//			item["column"].int_value(),
+//			item["line"].int_value(), 
+//			item["width"].int_value(), 
+//			item["height"].int_value(),
+//			graph[i].handle
+//		);		//JSONに書かれた情報をLoadDivGraphから読み込む
+//		graph[i].name = item["name"].string_value();	//JSONで指定された"name"はget()の引数に文字列として指定が可能
+//		graph[i].max = item["line"].int_value()*item["column"].int_value();
+////		slide = item["max"].number_value();
+//		i++;
+//	}
+	//load("player");	//試験用
 
 }
 //デストラクタ
@@ -52,19 +54,67 @@ GraphicResource::~GraphicResource()
 		delete graph[i].handle;	//画像は消さずにハンドル領域を削除する
 	}
 }
-bool GraphicResource::load(std::string scope)
+bool GraphicResource::load(std::string _scope)
 {
 	//scopeの文字列の画像をjsonから検索し、読み込む
 	//失敗すれば0、成功すれば0以外を返す
-	//処理は未実装
+	bool ret = false;
 	for (auto &item : json["graph"].array_items()) {
+		//scopeの配列をitemに格納する
+		for(auto &scope : item["scope"].array_items()) {
+			//scopeの文字列を順に比較する
+			if ( _scope == scope.string_value()) {
+				if (exist_name(item["name"].string_value()) == false) {
+					//同一の名前のファイルが読み込まれていない場合
+					register_graph(item);	//graphにitemを登録する
+					ret = true;
+					break;
+				}
+			}
+		}
 	}
-	return true;
+	return ret;
 }
 
 GraphicObject GraphicResource::get(std::string name)
 {
 	return graph[get_index(name)];
+}
+
+void GraphicResource::register_graph(json11::Json item)
+{
+	for (int i = 0; i < count_of_graph; i++) {
+		if (graph[i].exist == false) {
+			graph[i].handle = new int[count_of_graph];	//アニメーション画像のフレーム枚数分のハンドル領域を確保する
+			graph[i].exist = true;	//存在フラグを立てる
+			graph[i].name = item["name"].string_value();
+			graph[i].max = item["line"].int_value()*item["column"].int_value();	//最大枚数を求める
+			LoadDivGraph(
+				item["path"].string_value().c_str(),
+				item["column"].int_value() * item["line"].int_value(),
+				item["column"].int_value(),
+				item["line"].int_value(),
+				item["width"].int_value(),
+				item["height"].int_value(),
+				graph[i].handle
+			);		//JSONに書かれた情報をLoadDivGraphから読み込む
+			break;
+		}
+	}
+}
+
+bool GraphicResource::exist_name(std::string name)
+{
+	//nameが存在しているか調べるメソッド
+	bool ret = false;
+	for (int i = 0; i < count_of_graph; i++) {
+		if (graph[i].name == name) {
+			//存在していたら
+			ret = true;
+			break;
+		}
+	}
+	return ret;
 }
 
 int GraphicResource::get_index(std::string name)

--- a/Hide/GraphicResource.h
+++ b/Hide/GraphicResource.h
@@ -5,13 +5,18 @@
 #include "json11.hpp"
 
 struct GraphicObject {
-	GraphicObject(){
+	GraphicObject() {
 		exist = false;
+		loop = false;
+		max = 1;
+		rate = 0;
 	}
 	bool exist;
+	bool loop;	//ループの有無
 	std::string name;
 	int* handle;
-	int max;
+	int max;	//最大枚数
+	int rate;	//切替速度
 };
 
 class GraphicResource

--- a/Hide/GraphicResource.h
+++ b/Hide/GraphicResource.h
@@ -5,6 +5,7 @@
 #include "json11.hpp"
 
 struct GraphicObject {
+	bool exist= false;
 	std::string name;
 	int* handle;
 	int max;
@@ -20,8 +21,10 @@ public:
 	GraphicObject get(std::string);
 private:
 	int get_index(std::string);
-	json11::Json json;
+	bool exist_name(std::string);
+	void register_graph(json11::Json);
 
+	json11::Json json;
 	int count_of_graph;	//画像枚数
 	std::unique_ptr<GraphicObject[]> graph;
 };

--- a/Hide/GraphicResource.h
+++ b/Hide/GraphicResource.h
@@ -5,7 +5,10 @@
 #include "json11.hpp"
 
 struct GraphicObject {
-	bool exist= false;
+	GraphicObject(){
+		exist = false;
+	}
+	bool exist;
 	std::string name;
 	int* handle;
 	int max;
@@ -17,8 +20,8 @@ public:
 
 	GraphicResource();
 	~GraphicResource();
-	bool load(std::string);
-	GraphicObject get(std::string);
+	bool load(std::string _scope);
+	GraphicObject get(std::string name);
 private:
 	int get_index(std::string);
 	bool exist_name(std::string);

--- a/Hide/GraphicResource.h
+++ b/Hide/GraphicResource.h
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <memory>
 #include "GraphicState.h"
+#include "json11.hpp"
 
 struct GraphicObject {
 	std::string name;
@@ -18,7 +19,9 @@ public:
 	bool load(std::string);
 	GraphicObject get(std::string);
 private:
-	int count_of_graph;	//画像枚数
 	int get_index(std::string);
+	json11::Json json;
+
+	int count_of_graph;	//画像枚数
 	std::unique_ptr<GraphicObject[]> graph;
 };

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -69,13 +69,15 @@ Player::Player()
 	hp = 2;
 	interval = 0;
 	foot_status = false;
-	ct->keyboard->update(); //例外が発生する処理
-	//ct->graph;
-	GraphicObject obj = ct->graph->get("player");
-	graph = *obj.handle;
 	//graph = LoadGraph("img/player.png");
 	starmanager = std::make_unique<StarManager>();
 	playerinterface = std::make_unique<PlayerInterface>();
+
+}
+
+void Player::init()
+{
+	init_render("player");	//resource.jsonのnameが"player"のものをセットする
 }
 
 double Player::get_angle()
@@ -96,7 +98,7 @@ void Player::update()
 	//---------------------------------------
 	starmanager->update(angle, point.x);
 	playerinterface->update(hp,life);
-	draw();
+	draw(true);
 
 	DrawFormatString(0, 100, GetColor(255, 0, 0), "%d", foot_status);
 	DrawFormatString(0, 0, GetColor(255, 0, 0), "%d", point.x);

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -1,10 +1,10 @@
-#include "Player.h"
+ï»¿#include "Player.h"
 #include"Point.h"
 #include"CoreTask.h"
 #include"Keyboard.h"
 
 //----------------------------------
-//ƒvƒŒƒCƒ„[
+//ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼
 //----------------------------------
 
 Player::PlayerInterface::PlayerInterface()
@@ -16,9 +16,9 @@ Player::PlayerInterface::PlayerInterface()
 
 void Player::PlayerInterface::draw()
 {
-	//c‹@
+	//æ®‹æ©Ÿ
 	DrawGraph(500, 0, lifegraph, FALSE);
-	DrawFormatString(540, 0, GetColor(255, 255, 255), " ~ %d",life);
+	DrawFormatString(540, 0, GetColor(255, 255, 255), " Ã— %d",life);
 	//HP
 	for (int i = 0; i < 3; ++i) {
 		DrawGraph(40 * i, 0, hpfreamgraph, FALSE);
@@ -49,10 +49,10 @@ void Player::StarManager::update(double ang, int x_)
 {
 	draw(ang, x_);
 	if (ct->keyboard->key_down(KEY_INPUT_Z)) {
-		ct->gts->normalstar->lead();//ƒŠƒXƒg‚ğæ“ª‚É–ß‚·
-		//ƒm[ƒ}ƒ‹ƒXƒ^[
+		ct->gts->normalstar->lead();//ãƒªã‚¹ãƒˆã‚’å…ˆé ­ã«æˆ»ã™
+		//ãƒãƒ¼ãƒãƒ«ã‚¹ã‚¿ãƒ¼
 		std::shared_ptr<NormalStar> new_instance = std::make_shared<NormalStar>(0, 0, 0, ct->gts->player->point.x, ct->gts->player->get_angle());
-		ct->gts->normalstar->create(new_instance);//V‹KƒIƒuƒWƒFƒNƒg‚ğƒŠƒXƒgŠÇ—‘ÎÛ‚Æ‚·‚é
+		ct->gts->normalstar->create(new_instance);//æ–°è¦ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’ãƒªã‚¹ãƒˆç®¡ç†å¯¾è±¡ã¨ã™ã‚‹
 	}
 
 }
@@ -69,7 +69,11 @@ Player::Player()
 	hp = 2;
 	interval = 0;
 	foot_status = false;
-	graph = LoadGraph("img/player.png");
+	ct->keyboard->update(); //ä¾‹å¤–ãŒç™ºç”Ÿã™ã‚‹å‡¦ç†
+	//ct->graph;
+	GraphicObject obj = ct->graph->get("player");
+	graph = *obj.handle;
+	//graph = LoadGraph("img/player.png");
 	starmanager = std::make_unique<StarManager>();
 	playerinterface = std::make_unique<PlayerInterface>();
 }
@@ -81,7 +85,7 @@ double Player::get_angle()
 
 void Player::update()
 {
-	//‰¼‚ÌˆÚ“®‚ÆƒJ[ƒ\ƒ‹Šp“x’²®-------------
+	//ä»®ã®ç§»å‹•ã¨ã‚«ãƒ¼ã‚½ãƒ«è§’åº¦èª¿æ•´-------------
 	move();
 	if (ct->keyboard->key_press(KEY_INPUT_Q)) {
 		angle += 0.05;
@@ -110,8 +114,8 @@ void Player::draw_interface(int)
 
 void Player::move()
 {
-	//ŒÅ’è”’l‚Å‚Í‚È‚­velocity‚ğ“ü‚ê‚é
-	//Keyboard‚É•ÏX‚·‚é
+	//å›ºå®šæ•°å€¤ã§ã¯ãªãvelocityã‚’å…¥ã‚Œã‚‹
+	//Keyboardã«å¤‰æ›´ã™ã‚‹
 	if (ct->keyboard->key_press(KEY_INPUT_RIGHT)) {
 		point.x += 2;
 	}
@@ -129,11 +133,11 @@ void Player::move()
 
 void Player::check_foot()
 {
-	//¡‚Ì‰æ‘œ‚Ì‘å‚«‚³‚ª30*30‚Ì‚½‚ß
+	//ä»Šã®ç”»åƒã®å¤§ãã•ãŒ30*30ã®ãŸã‚
 	Point foot{ point.x,point.y + 30,30,1 };
 	DrawBox(foot.x, foot.y, foot.x + foot.w, foot.y + foot.h, GetColor(0, 255, 0), TRUE);
-	//‰¼‚Ì“–‚½‚è”»’è
-	//Map‚ÌGet_bottom‚ğŒÄ‚Ô?
+	//ä»®ã®å½“ãŸã‚Šåˆ¤å®š
+	//Mapã®Get_bottomã‚’å‘¼ã¶?
 	if (ct->gts->map->get_bottom(foot) != 0) {
 		foot_status = true;
 	}

--- a/Hide/Player.h
+++ b/Hide/Player.h
@@ -11,6 +11,7 @@
 class Player :public Physic {
 public:
 	Player();
+	void init();
 	//メソッド
 	double get_angle();//星の移動のために角度情報が必要
 	void update();//更新処理
@@ -24,6 +25,7 @@ public:
 	class PlayerInterface {
 	public:
 		PlayerInterface();
+		
 		//メソッド
 		void draw();
 		void update(int ,int);

--- a/Hide/Player.h
+++ b/Hide/Player.h
@@ -1,30 +1,30 @@
-#pragma once
+ï»¿#pragma once
 #include"Physic.h"
 #include"DxLib.h"
 #include<memory>
 
 
 //---------------------------------
-//ƒvƒŒƒCƒ„[
+//ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼
 //---------------------------------
 
 class Player :public Physic {
 public:
 	Player();
-	//ƒƒ\ƒbƒh
-	double get_angle();//¯‚ÌˆÚ“®‚Ì‚½‚ß‚ÉŠp“xî•ñ‚ª•K—v
-	void update();//XVˆ—
-	bool damage(void);//ƒ_ƒ[ƒW‚ğó‚¯‚éˆ—
-	void draw_interface(int);//UI•`‰æ
-	void move();//ˆÚ“®ˆ—
-	void check_foot();//‘«Œ³”»’è
-	bool knockback(int);//ƒmƒbƒNƒoƒbƒN
+	//ãƒ¡ã‚½ãƒƒãƒ‰
+	double get_angle();//æ˜Ÿã®ç§»å‹•ã®ãŸã‚ã«è§’åº¦æƒ…å ±ãŒå¿…è¦
+	void update();//æ›´æ–°å‡¦ç†
+	bool damage(void);//ãƒ€ãƒ¡ãƒ¼ã‚¸ã‚’å—ã‘ã‚‹å‡¦ç†
+	void draw_interface(int);//UIæç”»
+	void move();//ç§»å‹•å‡¦ç†
+	void check_foot();//è¶³å…ƒåˆ¤å®š
+	bool knockback(int);//ãƒãƒƒã‚¯ãƒãƒƒã‚¯
 
-	//ƒvƒŒƒCƒ„[ƒCƒ“ƒ^[ƒtƒFƒCƒX
+	//ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼ã‚¤ãƒ³ã‚¿ãƒ¼ãƒ•ã‚§ã‚¤ã‚¹
 	class PlayerInterface {
 	public:
 		PlayerInterface();
-		//ƒƒ\ƒbƒh
+		//ãƒ¡ã‚½ãƒƒãƒ‰
 		void draw();
 		void update(int ,int);
 	private:
@@ -35,11 +35,11 @@ public:
 		int lifegraph;
 	};
 
-	//¯‚ğo‚·ƒJ[ƒ\ƒ‹
+	//æ˜Ÿã‚’å‡ºã™ã‚«ãƒ¼ã‚½ãƒ«
 	class StarManager {
 	public:
 		StarManager();
-		//ƒƒ\ƒbƒh
+		//ãƒ¡ã‚½ãƒƒãƒ‰
 		void draw(double st, int x);
 		void update(double ang,int x);
 	private:
@@ -48,14 +48,14 @@ public:
 	};
 
 protected:
-	//•Ï”
-	int life;//c‹@
-	double angle;//ƒJ[ƒ\ƒ‹‚ÌŒX‚«
-	int invincible;//–³“GŠÔ
+	//å¤‰æ•°
+	int life;//æ®‹æ©Ÿ
+	double angle;//ã‚«ãƒ¼ã‚½ãƒ«ã®å‚¾ã
+	int invincible;//ç„¡æ•µæ™‚é–“
 	int hp;//HP
-	int interval;//¯‚Ì”­ËŠÔŠu
-	bool foot_status;//İ’u‚µ‚Ä‚¢‚é‚©
-	bool knockback_status;//ƒmƒbƒNƒoƒbƒN’†‚©
+	int interval;//æ˜Ÿã®ç™ºå°„é–“éš”
+	bool foot_status;//è¨­ç½®ã—ã¦ã„ã‚‹ã‹
+	bool knockback_status;//ãƒãƒƒã‚¯ãƒãƒƒã‚¯ä¸­ã‹
 	std::unique_ptr<StarManager> starmanager;
 	std::unique_ptr<PlayerInterface> playerinterface;
 };

--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -1,12 +1,32 @@
-#include "Rendering.h"
+﻿#include "Rendering.h"
 #include"DxLib.h"
+#include "CoreTask.h"
 
 bool Rendering::switch_anime()
 {
 	return false;
 }
 
-void Rendering::draw()
+void Rendering::draw(bool new_gen)
 {
-	DrawGraph(point.x, point.y, graph, 1);
+	if (new_gen == false) {
+		//旧世代のhandleがintのタイプ、アニメーション不可
+		//廃止予定の処理！！
+		DrawGraph(point.x, point.y, graph, 1);
+	}
+	else {
+		//新世代のhandleがint*タイプ、可変長のアニメーション可
+		DrawGraph(point.x, point.y, *(handle_graph + cnt), 1);
+	}
+}
+
+void Rendering::init_render(std::string scope)
+{
+	GraphicObject obj = ct->graph->get(scope);
+	if (obj.exist == false) throw "存在しない画像スコープ";
+	cnt = 0;
+	max = obj.max;
+	rate = obj.rate;
+	loop = obj.loop;
+	handle_graph = obj.handle;
 }

--- a/Hide/Rendering.h
+++ b/Hide/Rendering.h
@@ -1,16 +1,21 @@
-#pragma once
+ï»¿#pragma once
 #include"BasicObject.h"
+#include "GraphicResource.h"
 
 class Rendering : public BasicObject {
-public:
-	Rendering() {
-		
-	}
-	//ƒAƒjƒ[ƒVƒ‡ƒ“‚ğØ‚è‘Ö‚¦‚é
-	bool switch_anime();
-	void draw();
+private:
+	int max;	//æœ€å¤§æšæ•°
+	int rate; //åˆ‡æ›¿é€Ÿåº¦
+	int cnt;//ä½•æšç›®ã«ã„ã‚‹ã‹
+	bool loop;//ãƒ«ãƒ¼ãƒ—ã™ã‚‹ã‹
+
 protected:
-	int cnt;//‰½–‡–Ú‚É‚¢‚é‚©
-	bool loop;//ƒ‹[ƒv‚·‚é‚©
-	int graph;
+	int graph;	//ã“ã‚Œã¯*handle_graphã«ç§»è¡Œã™ã‚‹å»ƒæ­¢äºˆå®šã®ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£
+	int *handle_graph;
+
+	//ã‚¢ãƒ‹ãƒ¡ãƒ¼ã‚·ãƒ§ãƒ³ã‚’åˆ‡ã‚Šæ›¿ãˆã‚‹
+	void init_render(std::string scope);
+	bool switch_anime();
+	void draw(bool new_gen=false);
+
 };

--- a/Hide/img/resource.json
+++ b/Hide/img/resource.json
@@ -19,7 +19,8 @@
       "line": 1,
       "column": 1,
       "scope": [
-        "player"
+        "player",
+        "star"
       ]
     }
   ]

--- a/Hide/img/resource.json
+++ b/Hide/img/resource.json
@@ -1,22 +1,26 @@
-﻿{
+{
   "graph": [
     {
       "name" :  "player",
-      "path": "/hoge",
-      "width": 32,
-      "height": 32,
+      "path": "img/player.png",
+      "width": 30,
+      "height": 30,
       "line": 1,
-      "column": 4,
-      "scope": "all"
+      "column": 1,
+      "scope": [
+        "player"
+      ]
     },
     {
-      "name": "プログラム内識別子",
-      "path": "画像パス",
-      "width": "1マスの横幅(px)",
-      "height": "1マスの縦幅(px)",
-      "line": "画像の行数",
-      "column": "画像の列数",
-      "scope": "読み込み時の範囲(未実装の機能)"
+      "name": "star",
+      "path": "img/star.png",
+      "width": 30,
+      "height": 30,
+      "line": 1,
+      "column": 1,
+      "scope": [
+        "player"
+      ]
     }
   ]
 }

--- a/Hide/main.cpp
+++ b/Hide/main.cpp
@@ -1,40 +1,41 @@
-#include "DxLib.h"
+ï»¿#include "DxLib.h"
 #include"CoreTask.h"
 #include"Player.h"
 
 //----------------------------------
-//ƒNƒ‰ƒXì¬‚ÌÛAŠÖ”iƒƒ\ƒbƒhj‚Ípublic
-//•Ï”‚Íprivate‚Å“ü‚ê‚Ä‚­‚¾‚³‚¢(WET)
+//ã‚¯ãƒ©ã‚¹ä½œæˆã®éš›ã€é–¢æ•°ï¼ˆãƒ¡ã‚½ãƒƒãƒ‰ï¼‰ã¯public
+//å¤‰æ•°ã¯privateã§å…¥ã‚Œã¦ãã ã•ã„(Wãƒ»T)
 //----------------------------------
 
 CoreTask *ct;
 
-// WinMainŠÖ”
+// WinMainé–¢æ•°
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	LPSTR lpCmdLine, int nCmdShow)
 {
-	// ‰æ–Êƒ‚[ƒh‚Ìİ’è
-	SetGraphMode(600, 600, 32);//ƒEƒBƒ“ƒhƒE‚ÌƒTƒCƒY‚ğŒˆ‚ß‚é
-	ChangeWindowMode(TRUE);// ƒEƒBƒ“ƒhƒEƒ‚[ƒh•ÏX
+	// ç”»é¢ãƒ¢ãƒ¼ãƒ‰ã®è¨­å®š
+	SetGraphMode(600, 600, 32);//ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚µã‚¤ã‚ºã‚’æ±ºã‚ã‚‹
+	ChangeWindowMode(TRUE);// ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ¢ãƒ¼ãƒ‰å¤‰æ›´
 
-	// ‚c‚wƒ‰ƒCƒuƒ‰ƒŠ‰Šú‰»ˆ—
+	// ï¼¤ï¼¸ãƒ©ã‚¤ãƒ–ãƒ©ãƒªåˆæœŸåŒ–å‡¦ç†
 	if (DxLib_Init() == -1) { return -1; };
 	
 	SetMainWindowText("Stern");
 
 
 	ct = new CoreTask;
-
+	ct->graph->load("player");	//resource.jsonã®scopeã«playerãŒå«ã¾ã‚Œã¦ã„ã‚‹ç”»åƒã‚’å…¨ã¦ãƒ­ãƒ¼ãƒ‰
+	ct->gts->player->init();	//init_render("player"); ã‚’å®Ÿè¡Œã€‚resource.jsonã®nameãŒ"player"ã®ç”»åƒã‚’ã‚»ãƒƒãƒˆã™ã‚‹
 	//-------------------------------------------------
-	SetDrawScreen(DX_SCREEN_BACK);//— ‰æ–Êİ’è
+	SetDrawScreen(DX_SCREEN_BACK);//è£ç”»é¢è¨­å®š
 
-	while (ScreenFlip() == 0 && ProcessMessage() == 0 && ClearDrawScreen() == 0) {//‰æ–ÊXV•ƒƒbƒZ[ƒWˆ—&‰æ–ÊEŠQ
+	while (ScreenFlip() == 0 && ProcessMessage() == 0 && ClearDrawScreen() == 0) {//ç”»é¢æ›´æ–°ï¼†ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å‡¦ç†&ç”»é¢æ®ºå®³
 		
 		ct->update();
 
 	}
 	delete ct;
-	DxLib_End();				// ‚c‚wƒ‰ƒCƒuƒ‰ƒŠg—p‚ÌI—¹ˆ—
+	DxLib_End();				// ï¼¤ï¼¸ãƒ©ã‚¤ãƒ–ãƒ©ãƒªä½¿ç”¨ã®çµ‚äº†å‡¦ç†
 
-	return 0;					// ƒ\ƒtƒg‚ÌI—¹
+	return 0;					// ã‚½ãƒ•ãƒˆã®çµ‚äº†
 }


### PR DESCRIPTION
Playerのみでの実行テストパス！！！
GraphicResourceと合わせてRenderingも大幅刷新！！

**メモリから画像読み込み処理**
従来：LoadGraph(....);
現在：ct->graph->load("player");  //playerは例

**アニメーション切り替え**
従来：困難
現在：Playerクラスのメソッドにて、init_render("running_right")  //running_rightは例

**resource.jsonについて**
サンプルファイル
```
{
  "graph": [
    {
      "name" :  "player",
      "path": "img/player.png",
      "width": 30,
      "height": 30,
      "line": 1,
      "column": 1,
      "scope": [
        "player"
      ]
    },
    {
      "name": "star",
      "path": "img/star.png",
      "width": 30,
      "height": 30,
      "line": 1,
      "column": 1,
      "scope": [
        "player",
        "star"
      ]
    }
  ]
}
```
== scopeについて ==
ct->graph->load("star") と書くと "name" : "star" の画像のみが読み込まれる。
ct->graph->load("player") と書くと "name" : "star" の画像と "name" : "player" の2枚の画像を読み込むことが可能。
複数回同じ画像を読み込んでも2回め以降は読み込まないため重複を気にする必要はなし。
scopeに関しては一意でなくてもよい。

== nameについて ==
エンティティのメソッドにおいて利用することが可能な rendering クラスに定義されているメソッド init_render()において利用が可能。
init_render("star"); とするとjsonに記述されているフォーマットで画像を読み込み draw()だけて描画が可能になる。
nameに関しては一意である必要がある。

== 初期値について ==
上記JSONファイルには以下の項目を設定するこができるようになっている。
・name 画像識別子、必須の項目
・path  画像パス、必須の項目
・width  1コマの横幅、省略時は32
・height 1コマの縦幅、省略時は32
・line      画像の行数、省略時は1
・column 画像の列数、省略時は1
・scope　画像の範囲、必須の項目