### PR TITLE
星を出すと敵が消える問題修正

### DIFF
--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -30,12 +30,14 @@ void GameTaskSystem::update()
 
 	map->update();
 	//☆------------------------------
+	normalstar->lead();
 	while (normalstar->exist()) {
 		normalstar->get()->update();
 		normalstar->proceed();
 	}
 	//--------------------------------
 	//敵------------------------------
+	walking_enemy->lead();
 	while (walking_enemy->exist()) {
 		walking_enemy->get()->update();
 		walking_enemy->proceed();


### PR DESCRIPTION
リストが先頭に戻っていなかったため、先頭に戻すように修正。