### PR TITLE
NormalStarのvector化

### DIFF
--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -13,7 +13,6 @@ GameTaskSystem::GameTaskSystem()
 	map = std::make_unique<Map>();
 	player = std::make_unique<Player>(p_point,p_physic_state,player_state);
 
-	//normalstar = std::make_shared<BasicList<NormalStar>>();
 	walking_enemy = std::make_shared<BasicList<WalkingEnemy>>();
 	boss = std::make_shared<BasicList<Boss>>();
 	flying_enemy = std::make_shared<BasicList<FlyingEnemy>>();

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -13,7 +13,7 @@ GameTaskSystem::GameTaskSystem()
 	map = std::make_unique<Map>();
 	player = std::make_unique<Player>(p_point,p_physic_state,player_state);
 
-	normalstar = std::make_shared<BasicList<NormalStar>>();
+	//normalstar = std::make_shared<BasicList<NormalStar>>();
 	walking_enemy = std::make_shared<BasicList<WalkingEnemy>>();
 	boss = std::make_shared<BasicList<Boss>>();
 	flying_enemy = std::make_shared<BasicList<FlyingEnemy>>();
@@ -34,15 +34,12 @@ void GameTaskSystem::init()
 void GameTaskSystem::update()
 {
 	//リストを先頭に戻す
-	normalstar->lead();
 	walking_enemy->lead();
 	map->update();
 	goal->update();
 	//☆------------------------------
-	normalstar->lead();
-	while (normalstar->exist()) {
-		normalstar->get()->update();
-		normalstar->proceed();
+	for (auto itr = normalstar.begin(); itr != normalstar.end(); itr++) {
+		itr->update();
 	}
 	//--------------------------------
 	//敵------------------------------

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include "Player.h"
 #include"Map.h"
 #include<memory>
@@ -23,9 +23,9 @@ public:
 	std::unique_ptr<Player> player;
 	std::unique_ptr<Map> map;
 	std::unique_ptr<Goal> goal;
-	//™
-	std::shared_ptr<BasicList<NormalStar>> normalstar;
-	//“G
+	//â˜†
+	std::vector<NormalStar> normalstar;
+	//æ•µ
 	std::shared_ptr<BasicList<WalkingEnemy>> walking_enemy;
 	std::shared_ptr<BasicList<FlyingEnemy>>  flying_enemy;
 	std::shared_ptr<BasicList<Boss>> boss;

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -49,14 +49,13 @@ void Player::StarManager::update(double ang, int x_)
 {
 	draw(ang, x_);
 	if (ct->keyboard->key_down(KEY_INPUT_Z)) {
-		ct->gts->normalstar->lead();//リストを先頭に戻す
-		//ノーマルスター
-		//Point point_, PhysicState physic_state_, StarState star_state
 		class Point point = { x_,0,0,0 };
 		struct PhysicState physic_state = { 0,0,0 };//	float gravity; float repulsion;int weight;
 		struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
-		std::shared_ptr<NormalStar> new_instance = std::make_shared<NormalStar>(point,physic_state,star_state);
-		ct->gts->normalstar->create(new_instance);//新規オブジェクトをリスト管理対象とする
+
+		ct->gts->normalstar.push_back(NormalStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
+		//ノーマルスター
+		//Point point_, PhysicState physic_state_, StarState star_state
 	}
 }
 


### PR DESCRIPTION
BasicListに完全に置き換わる標準クラスvectorをNormalStarのみに実装。
実行テストによる動作確認済み。
Destroy問題の解決と動作速度向上に役立つ。
さらばBasicList、、、