### PR TITLE
Renderingクラスのdraw()を更新

### DIFF
--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -16,11 +16,11 @@ void Rendering::draw(bool new_gen)
 	if (new_gen == false) {
 		//旧世代のhandleがintのタイプ、アニメーション不可
 		//廃止予定の処理！！
-		DrawGraph(point.x, point.y, graph, 1);
+		//DrawGraph(point.x, point.y, graph, 1);
 	}
 	else {
 		//新世代のhandleがint*タイプ、可変長のアニメーション可
-		DrawGraph(point.x, point.y, *(handle_graph + cnt), 1);
+		DrawGraph(point.x - ct->gts->camera->get_range().x , point.y , *(handle_graph + cnt), 1);
 		current_rate++;	//毎フレーム増える
 		if (rate != 0 && rate % current_rate == 0) {
 			switch_anime();

--- a/Hide/main.cpp
+++ b/Hide/main.cpp
@@ -33,7 +33,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	SetDrawScreen(DX_SCREEN_BACK);//裏画面設定
 
 	while (ScreenFlip() == 0 && ProcessMessage() == 0 && ClearDrawScreen() == 0) {//画面更新＆メッセージ処理&画面殺害
-		
+		if (ct->keyboard->key_down(KEY_INPUT_ESCAPE))break;	//xボタンで終了するとメモリリークが起こるため。
 		ct->update();
 
 	}


### PR DESCRIPTION
カメラを基準として描画位置をずらすように変更。
マップは固定座標に描画されているためマップは変化しない。
Renderingクラスを継承したオブジェクトの描画に関しては実行テスト済み。