### PR TITLE
Enemyを一つのクラスとして扱うように仕様を変更

### DIFF
--- a/Hide/BossEnemy.cpp
+++ b/Hide/BossEnemy.cpp
@@ -10,7 +10,3 @@ Boss::Boss(Point point_, PhysicState physic_state_, EnemyState enemy_state_) : E
 void Boss::move()
 {
 }
-
-void Boss::update()
-{
-}

--- a/Hide/BossEnemy.h
+++ b/Hide/BossEnemy.h
@@ -1,16 +1,15 @@
-#pragma once
+ï»¿#pragma once
 #include"Enemy.h"
 
 //--------------------------------
-//ƒ{ƒX“G
+//ãƒœã‚¹æ•µ
 //--------------------------------
 
 class Boss : public Enemy {
 public:
 	Boss(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	//ƒƒ\ƒbƒh
+	//ãƒ¡ã‚½ãƒƒãƒ‰
 	void move();
-	void update();
 
 protected:
 private:

--- a/Hide/BossEnemy.h
+++ b/Hide/BossEnemy.h
@@ -9,7 +9,7 @@ class Boss : public Enemy {
 public:
 	Boss(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
 	//メソッド
-	void move();
+	void move() override;
 
 protected:
 private:

--- a/Hide/BulletEnemy.cpp
+++ b/Hide/BulletEnemy.cpp
@@ -19,10 +19,3 @@ void BulletEnemy::move()
 	velocityX = (float)angle;
 	point.x += (int)velocityX;
 }
-
-void BulletEnemy::update()
-{
-	move();
-	exercise();
-	draw(true);
-}

--- a/Hide/BulletEnemy.h
+++ b/Hide/BulletEnemy.h
@@ -4,7 +4,7 @@
 class BulletEnemy : public Enemy {
 public:
 	BulletEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	void move();
+	void move() override;
 private:
 	int angle;
 protected:

--- a/Hide/BulletEnemy.h
+++ b/Hide/BulletEnemy.h
@@ -5,7 +5,6 @@ class BulletEnemy : public Enemy {
 public:
 	BulletEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
 	void move();
-	void update();
 private:
 	int angle;
 protected:

--- a/Hide/Enemy.cpp
+++ b/Hide/Enemy.cpp
@@ -24,6 +24,7 @@ bool Enemy::attack()
 
 void Enemy::update()
 {
+	move();
 	exercise();
 	attack();
 	draw(true);
@@ -36,4 +37,8 @@ bool Enemy::damage(int d_)
 		return true;
 	}
 	return false;
+}
+
+void Enemy::move() {
+
 }

--- a/Hide/Enemy.cpp
+++ b/Hide/Enemy.cpp
@@ -24,8 +24,9 @@ bool Enemy::attack()
 
 void Enemy::update()
 {
-	this->exercise();
-	this->attack();
+	exercise();
+	attack();
+	draw(true);
 }
 
 bool Enemy::damage(int d_)

--- a/Hide/Enemy.cpp
+++ b/Hide/Enemy.cpp
@@ -38,7 +38,3 @@ bool Enemy::damage(int d_)
 	}
 	return false;
 }
-
-void Enemy::move() {
-
-}

--- a/Hide/Enemy.h
+++ b/Hide/Enemy.h
@@ -30,9 +30,9 @@ public :
 	virtual void move() {
 
 	}
-	bool attack();
-	void update();
-	bool damage(int);
+	virtual bool attack();
+	virtual void update();
+	virtual bool damage(int);
 
 protected:
 	//•Ï”

--- a/Hide/Enemy.h
+++ b/Hide/Enemy.h
@@ -29,7 +29,7 @@ public :
 	Enemy(Point point, PhysicState physic_state, EnemyState enemy_state);
 	//メソッド
 	virtual void update() final;
-	virtual bool damage(int);
+	virtual bool damage(int) final;
 
 protected:
 	//プロパティ
@@ -39,6 +39,6 @@ protected:
 	AngleState anglestate;
 	//メソッド
 	virtual void move() = 0;	//抽象クラス
-	bool attack();
+	virtual bool attack() final;
 
 };

--- a/Hide/Enemy.h
+++ b/Hide/Enemy.h
@@ -1,11 +1,11 @@
-#pragma once
+ï»¿#pragma once
 #include"Physic.h"
 
 //----------------------------------
-//“G‘S”Ê
+//æ•µå…¨èˆ¬
 //----------------------------------
 
-//Enemy‚É‹¤’Ê‚·‚é‚½‚ßEnemyClass‚É‚¢‚ê‚Ä‚à‚¢‚¢‚©‚à‚µ‚ê‚È‚¢
+//Enemyã«å…±é€šã™ã‚‹ãŸã‚EnemyClassã«ã„ã‚Œã¦ã‚‚ã„ã„ã‹ã‚‚ã—ã‚Œãªã„
 enum class AngleState {
 	left,
 	right
@@ -18,27 +18,27 @@ struct EnemyState {
 };
 
 class Enemy :public Physic {
-	//ƒƒ“ƒo[ŠÖ”
+private:
+	//ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£
 	int life;
 	int damaged;
 	int gravity;
-public :
-	//ƒƒ\ƒbƒh
-	//ƒRƒ“ƒXƒgƒ‰ƒNƒ^
-	Enemy(Point point, PhysicState physic_state,EnemyState enemy_state);
-	//‰¼‘zŠÖ”
-	virtual void move() {
 
-	}
-	virtual bool attack();
+
+public :
+	Enemy(Point point, PhysicState physic_state, EnemyState enemy_state);
+	//ãƒ¡ã‚½ãƒƒãƒ‰
 	virtual void update();
 	virtual bool damage(int);
 
 protected:
-	//•Ï”
-	int hp;//c‚è‘Ì—Í
+	//ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£
+	int hp;//æ®‹ã‚Šä½“åŠ›
 	int power;
 	int knock_back;
 	AngleState anglestate;
+	//ãƒ¡ã‚½ãƒƒãƒ‰
+	virtual void move();
+	virtual bool attack();
 
 };

--- a/Hide/Enemy.h
+++ b/Hide/Enemy.h
@@ -28,7 +28,7 @@ private:
 public :
 	Enemy(Point point, PhysicState physic_state, EnemyState enemy_state);
 	//メソッド
-	virtual void update();
+	virtual void update() final;
 	virtual bool damage(int);
 
 protected:
@@ -38,7 +38,7 @@ protected:
 	int knock_back;
 	AngleState anglestate;
 	//メソッド
-	virtual void move();
-	virtual bool attack();
+	virtual void move() = 0;	//抽象クラス
+	bool attack();
 
 };

--- a/Hide/EnemyShot00.h
+++ b/Hide/EnemyShot00.h
@@ -5,7 +5,6 @@ class EnemyShot00 : public Enemy {
 
 public:
 	EnemyShot00(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	void update();
 private:
 protected:
 };

--- a/Hide/FlyingEnemy.cpp
+++ b/Hide/FlyingEnemy.cpp
@@ -15,6 +15,7 @@ FlyingEnemy::FlyingEnemy(Point point_, PhysicState physic_state_, EnemyState ene
 
 void FlyingEnemy::move()
 {
+	change_state();
 	switch (flyingstate)
 	{
 		//飛行

--- a/Hide/FlyingEnemy.cpp
+++ b/Hide/FlyingEnemy.cpp
@@ -55,11 +55,3 @@ void FlyingEnemy::change_state()
 	}
 }
 
-void FlyingEnemy::update()
-{
-	//exercise();
-	change_state();
-	move();
-	attack();
-	draw(true);
-}

--- a/Hide/FlyingEnemy.h
+++ b/Hide/FlyingEnemy.h
@@ -18,7 +18,6 @@ public:
 	FlyingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
 	void move();
 	void change_state();
-	void update();
 private:
 	int movecnt;//ブロックに当たっている間とり誤差をなくしたかった
 protected:

--- a/Hide/FlyingEnemy.h
+++ b/Hide/FlyingEnemy.h
@@ -16,7 +16,7 @@ public:
 	FlyingState flyingstate;
 
 	FlyingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	void move();
+	void move() override;
 	void change_state();
 private:
 	int movecnt;//ブロックに当たっている間とり誤差をなくしたかった

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -15,6 +15,7 @@ GameTaskSystem::GameTaskSystem()
 	camera = std::make_unique<Camera>();
 	player = std::make_unique<Player>(p_point, p_physic_state, player_state);
 	enemys = std::make_shared<std::vector<std::unique_ptr<Enemy>>>();
+	enemy_transaction = std::make_shared<std::vector<std::unique_ptr<Enemy>>>();
 }
 
 GameTaskSystem::~GameTaskSystem()
@@ -46,6 +47,12 @@ void GameTaskSystem::update()
 	//--------------------------------
 	player->update();
 	camera->update();
+
+	//トランザクションの実行
+	for (auto itr = enemy_transaction->begin(); itr != enemy_transaction->end(); ++itr) {
+		enemys->push_back(std::move((*itr)));	//トランザクションから実体へ所有権を移動する
+	}
+	enemy_transaction->clear();	//enemy_transactionを空にする
 }
 
 void GameTaskSystem::finalize()

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -38,16 +38,7 @@ void GameTaskSystem::update()
 	}
 	//--------------------------------
 	//敵------------------------------先頭から終端まで
-	for (auto itr = walking_enemy.begin(); itr != walking_enemy.end(); ++itr) {
-		itr->update();//歩行敵のupdateを呼ぶ
-	}
-	for (auto itr = flying_enemy.begin(); itr != flying_enemy.end(); ++itr) {
-		itr->update();
-	}
-	for (auto itr = throwing_enemy.begin(); itr != throwing_enemy.end(); ++itr) {
-		itr->update();
-	}
-	for (auto itr = enemy_bullet.begin(); itr != enemy_bullet.end(); ++itr) {
+	for (auto itr = enemys.begin(); itr != enemys.end(); ++itr) {
 		itr->update();
 	}
 	//--------------------------------
@@ -61,16 +52,7 @@ void GameTaskSystem::finalize()
 	while (!normalstar.empty()) {//空でないなら
 		normalstar.pop_back();//消し去る
 	}
-	while (!walking_enemy.empty()) {
-		walking_enemy.pop_back();
-	}
-	while (!flying_enemy.empty()) {
-		flying_enemy.pop_back();
-	}
-	while (!throwing_enemy.empty()) {
-		throwing_enemy.pop_back();
-	}
-	while (!enemy_bullet.empty()) {
-		enemy_bullet.pop_back();
+	while (!enemys.empty()) {
+		enemys.pop_back();
 	}
 }

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -57,10 +57,6 @@ void GameTaskSystem::update()
 
 void GameTaskSystem::finalize()
 {
-	while (!normalstar.empty()) {//空でないなら
-		normalstar.pop_back();//消し去る
-	}
-	while (!enemys->empty()) {
-		enemys->pop_back();
-	}
+	normalstar.clear();
+	enemys->clear();
 }

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -1,5 +1,6 @@
 ﻿#include "GameTaskSystem.h"
 #include <vector> 
+#include <memory>
 
 GameTaskSystem::GameTaskSystem()
 {
@@ -13,6 +14,7 @@ GameTaskSystem::GameTaskSystem()
 	map = std::make_unique<Map>();
 	camera = std::make_unique<Camera>();
 	player = std::make_unique<Player>(p_point, p_physic_state, player_state);
+	enemys = std::make_shared<std::vector<std::unique_ptr<Enemy>>>();
 }
 
 GameTaskSystem::~GameTaskSystem()
@@ -38,11 +40,10 @@ void GameTaskSystem::update()
 	}
 	//--------------------------------
 	//敵------------------------------先頭から終端まで
-	for (auto itr = enemys.begin(); itr != enemys.end(); ++itr) {
-		itr->update();
+	for (auto itr = enemys->begin(); itr != enemys->end(); ++itr){
+		(*itr)->update();
 	}
 	//--------------------------------
-
 	player->update();
 	camera->update();
 }
@@ -52,7 +53,7 @@ void GameTaskSystem::finalize()
 	while (!normalstar.empty()) {//空でないなら
 		normalstar.pop_back();//消し去る
 	}
-	while (!enemys.empty()) {
-		enemys.pop_back();
+	while (!enemys->empty()) {
+		enemys->pop_back();
 	}
 }

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -31,7 +31,8 @@ public:
 	//☆
 	std::vector<NormalStar> normalstar;
 	//敵
-	std::shared_ptr<std::vector<std::unique_ptr<Enemy> > > enemys;
+	std::shared_ptr<std::vector<std::unique_ptr<Enemy>>> enemys;
+	std::shared_ptr<std::vector<std::unique_ptr<Enemy>>> enemy_transaction;
 
 };
 

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -31,10 +31,6 @@ public:
 	//☆
 	std::vector<NormalStar> normalstar;
 	//敵
-	std::vector<WalkingEnemy> walking_enemy;
-	std::vector<FlyingEnemy>  flying_enemy;
-	std::vector<Boss> boss;
-	std::vector<ThrowingEnemy> throwing_enemy;
-	std::vector<BulletEnemy> enemy_bullet;
+	std::vector<Enemy> enemys;
 };
 

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -31,6 +31,7 @@ public:
 	//☆
 	std::vector<NormalStar> normalstar;
 	//敵
-	std::vector<Enemy> enemys;
+	std::shared_ptr<std::vector<std::unique_ptr<Enemy>>> enemys;
+
 };
 

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -31,7 +31,7 @@ public:
 	//☆
 	std::vector<NormalStar> normalstar;
 	//敵
-	std::shared_ptr<std::vector<std::unique_ptr<Enemy>>> enemys;
+	std::shared_ptr<std::vector<std::unique_ptr<Enemy> > > enemys;
 
 };
 

--- a/Hide/SpawnEnemy.cpp
+++ b/Hide/SpawnEnemy.cpp
@@ -32,17 +32,17 @@ void SpawnEnemy::create(std::string stg)
 		//歩行
 		if(enemy["kind"].string_value() == "walk") {
 			//生成して現在の最後尾に登録
-			ct->gts->enemys.push_back(WalkingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys->push_back(std::make_unique<WalkingEnemy>(point, physic_state, enemy_state));
 		}	
 		//飛行
 		if (enemy["kind"].string_value() == "fly") {
 			//生成して現在の最後尾に登録
-			ct->gts->enemys.push_back(FlyingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys->push_back(std::make_unique<FlyingEnemy>(point,physic_state,enemy_state ));
 		}
 		//投げつける奴
 		if (enemy["kind"].string_value() == "throw") {
 			//生成して現在の最後尾に登録
-			ct->gts->enemys.push_back(ThrowingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys->push_back(std::make_unique<ThrowingEnemy>( point,physic_state,enemy_state ));
 		}
 	}
 }

--- a/Hide/SpawnEnemy.cpp
+++ b/Hide/SpawnEnemy.cpp
@@ -32,17 +32,17 @@ void SpawnEnemy::create(std::string stg)
 		//歩行
 		if(enemy["kind"].string_value() == "walk") {
 			//生成して現在の最後尾に登録
-			ct->gts->walking_enemy.push_back(WalkingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys.push_back(WalkingEnemy{ point,physic_state,enemy_state });
 		}	
 		//飛行
 		if (enemy["kind"].string_value() == "fly") {
 			//生成して現在の最後尾に登録
-			ct->gts->flying_enemy.push_back(FlyingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys.push_back(FlyingEnemy{ point,physic_state,enemy_state });
 		}
 		//投げつける奴
 		if (enemy["kind"].string_value() == "throw") {
 			//生成して現在の最後尾に登録
-			ct->gts->throwing_enemy.push_back(ThrowingEnemy{ point,physic_state,enemy_state });
+			ct->gts->enemys.push_back(ThrowingEnemy{ point,physic_state,enemy_state });
 		}
 	}
 }

--- a/Hide/Star.cpp
+++ b/Hide/Star.cpp
@@ -61,25 +61,7 @@ void Star::rebound_Y()
 bool Star::attack()
 {
 	Point enemy_point;
-	for (auto itr = ct->gts->walking_enemy.begin(); itr != ct->gts->walking_enemy.end(); ++itr) {
-		enemy_point = itr->get_point();
-		if (check_hit(enemy_point)) {
-			itr->damage(power);
-		}
-	}
-	for (auto itr = ct->gts->flying_enemy.begin(); itr != ct->gts->flying_enemy.end(); ++itr) {
-		enemy_point = itr->get_point();
-		if (check_hit(enemy_point)) {
-			itr->damage(power);
-		}
-	}
-	for (auto itr = ct->gts->throwing_enemy.begin(); itr != ct->gts->throwing_enemy.end(); ++itr) {
-		enemy_point = itr->get_point();
-		if (check_hit(enemy_point)) {
-			itr->damage(power);
-		}
-	}
-	for (auto itr = ct->gts->boss.begin(); itr != ct->gts->boss.end(); ++itr) {
+	for (auto itr = ct->gts->enemys.begin(); itr != ct->gts->enemys.end(); ++itr) {
 		enemy_point = itr->get_point();
 		if (check_hit(enemy_point)) {
 			itr->damage(power);

--- a/Hide/Star.cpp
+++ b/Hide/Star.cpp
@@ -61,10 +61,10 @@ void Star::rebound_Y()
 bool Star::attack()
 {
 	Point enemy_point;
-	for (auto itr = ct->gts->enemys.begin(); itr != ct->gts->enemys.end(); ++itr) {
-		enemy_point = itr->get_point();
+	for (auto itr = ct->gts->enemys->begin(); itr != ct->gts->enemys->end(); ++itr) {
+		enemy_point = (*itr)->get_point();
 		if (check_hit(enemy_point)) {
-			itr->damage(power);
+			(*itr)->damage(power);
 		}
 	}
 	return false;

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -22,7 +22,7 @@ void ThrowingEnemy::appear_shot()
 		struct PhysicState physic_state = { 0,0,0 };//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;
 
-		ct->gts->enemys.push_back(BulletEnemy{ b_point,physic_state,Enemy_state });	//新規インスタンスを生成して最後尾へ登録する
+		ct->gts->enemys->push_back(std::make_unique<BulletEnemy>(b_point,physic_state,Enemy_state ));	//新規インスタンスを生成して最後尾へ登録する
 		cnt = 0;
 	}
 }

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -12,7 +12,9 @@ ThrowingEnemy::ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState
 
 void ThrowingEnemy::move()
 {
+	cnt++;
 	change_angle();
+	appear_shot();
 }
 
 void ThrowingEnemy::appear_shot()
@@ -22,7 +24,7 @@ void ThrowingEnemy::appear_shot()
 		struct PhysicState physic_state = { 0,0,0 };//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;
 
-		ct->gts->enemys->push_back(std::make_unique<BulletEnemy>(b_point,physic_state,Enemy_state ));	//新規インスタンスを生成して最後尾へ登録する
+		ct->gts->enemy_transaction->push_back(std::make_unique<BulletEnemy>(b_point,physic_state,Enemy_state ));	//新規インスタンスを生成して最後尾へ登録する
 		cnt = 0;
 	}
 }

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -22,7 +22,7 @@ void ThrowingEnemy::appear_shot()
 		struct PhysicState physic_state = { 0,0,0 };//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;
 
-		ct->gts->enemy_bullet.push_back(BulletEnemy{ b_point,physic_state,Enemy_state });	//新規インスタンスを生成して最後尾へ登録する
+		ct->gts->enemys.push_back(BulletEnemy{ b_point,physic_state,Enemy_state });	//新規インスタンスを生成して最後尾へ登録する
 		cnt = 0;
 	}
 }

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -44,14 +44,5 @@ AngleState ThrowingEnemy::get_anglestate()
 	return anglestate;
 }
 
-void ThrowingEnemy::update()
-{
-	++cnt;
-	appear_shot();
-	exercise();
-	move();
-	DrawFormatString(400, 0, GetColor(0, 0, 0), "%d",cnt);
-	draw(true);
-}
 
 

--- a/Hide/ThrowingEnemy.h
+++ b/Hide/ThrowingEnemy.h
@@ -6,7 +6,6 @@ public:
 	ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
 	void move();//移動
 	void appear_shot();
-	void update();
 	void change_angle();
 	AngleState get_anglestate();
 

--- a/Hide/ThrowingEnemy.h
+++ b/Hide/ThrowingEnemy.h
@@ -4,7 +4,7 @@
 class ThrowingEnemy :public Enemy {
 public:
 	ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	void move();//移動
+	void move() override;//移動
 	void appear_shot();
 	void change_angle();
 	AngleState get_anglestate();

--- a/Hide/WalkingEnemy.cpp
+++ b/Hide/WalkingEnemy.cpp
@@ -11,6 +11,9 @@ WalkingEnemy::WalkingEnemy(Point point_, PhysicState physic_state_, EnemyState e
 
 void WalkingEnemy::move()
 {
+	check_left();
+	check_right();
+
 	switch (walkingstate)
 	{
 	//歩行
@@ -69,14 +72,4 @@ void WalkingEnemy::check_right()
 	if (ct->gts->map->get_right(right) != 0) {
 		anglestate = AngleState::left;
 	}
-}
-void WalkingEnemy::update()
-{
-	exercise();
-	move();
-	DrawFormatString(400, 0, GetColor(0, 0, 0), "%d", velocityX);
-	check_left();
-	check_right();
-	attack();
-	draw(true);
 }

--- a/Hide/WalkingEnemy.h
+++ b/Hide/WalkingEnemy.h
@@ -15,7 +15,6 @@ public:
   
 	WalkingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
 	void move();
-	void update();
 	void check_left();
 	void check_right();
 		

--- a/Hide/WalkingEnemy.h
+++ b/Hide/WalkingEnemy.h
@@ -14,7 +14,7 @@ public:
 	AngleState anglestate;
   
 	WalkingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_);
-	void move();
+	void move() override;
 	void check_left();
 	void check_right();
 		


### PR DESCRIPTION
WalkinEnemyやFlyingEnemyなどのサブクラスを一つにまとめ、同一オブジェクトとして扱えるように変更。
オブジェクトは同じだけれども異なる振る舞いをする(ポリモーフィズム)。
動作確認済み。