### PR TITLE
Renderingのdraw()の下位互換性を削除

### DIFF
--- a/Hide/Enemy.cpp
+++ b/Hide/Enemy.cpp
@@ -27,7 +27,7 @@ void Enemy::update()
 	move();
 	exercise();
 	attack();
-	draw(true);
+	draw();
 }
 
 bool Enemy::damage(int d_)

--- a/Hide/Goal.cpp
+++ b/Hide/Goal.cpp
@@ -30,7 +30,7 @@ bool Goal::hit(Point player_)
 	{
 		to_cleartask();
 	}
-	draw(true);
+	draw();
 	return false;
 }
 

--- a/Hide/NormalStar.cpp
+++ b/Hide/NormalStar.cpp
@@ -47,7 +47,7 @@ void NormalStar::update()
 	}
 	attack();
 
-	draw(true);
+	draw();
 	/*if (damage(1)) {
 		//ct->gts->normalstar->destroy();
 	}*/

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -97,7 +97,7 @@ void Player::update()
 	//---------------------------------------
 	starmanager->update(angle, point.x);
 	playerinterface->update(hp,life);
-	draw(true);
+	draw();
 	exercise();
 	DrawFormatString(0, 0, GetColor(255, 0, 0), "%d", point.x);//L
 	DrawFormatString(0, 50, GetColor(255, 0, 0), "%d", point.y);//T

--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -11,20 +11,12 @@ void Rendering::switch_anime()
 	}
 }
 
-void Rendering::draw(bool new_gen)
+void Rendering::draw()
 {
-	if (new_gen == false) {
-		//旧世代のhandleがintのタイプ、アニメーション不可
-		//廃止予定の処理！！
-		//DrawGraph(point.x, point.y, graph, 1);
-	}
-	else {
-		//新世代のhandleがint*タイプ、可変長のアニメーション可
-		DrawGraph(point.x - ct->gts->camera->get_range().x , point.y , *(handle_graph + cnt), 1);
-		current_rate++;	//毎フレーム増える
-		if (rate != 0 && rate % current_rate == 0) {
-			switch_anime();
-		}
+	DrawGraph(point.x - ct->gts->camera->get_range().x , point.y , *(handle_graph + cnt), 1);
+	current_rate++;	//毎フレーム増える
+	if (rate != 0 && rate % current_rate == 0) {
+		switch_anime();
 	}
 }
 

--- a/Hide/Rendering.h
+++ b/Hide/Rendering.h
@@ -14,12 +14,11 @@ private:
 	void switch_anime();
 
 protected:
-	int graph;	//これは*handle_graphに移行する廃止予定のプロパティ
 
 	//アニメーションを切り替える
 	void init_render(std::string scope);
 
-	void draw(bool new_gen=false);
+	void draw();
 
 public:
 	Rendering(Point point);


### PR DESCRIPTION
予告通りdraw()の処理を引数により分けて下位互換を維持しているコードを削除し、互換性をなくしました。
draw()は**引数を受け付けません**が、動作を一本にしたため問題ありません。