### PR TITLE
RenderingクラスをBasicObjectから独立させた

### DIFF
--- a/Hide/Audio.cpp
+++ b/Hide/Audio.cpp
@@ -12,6 +12,7 @@ Audio::Audio()
 	std::string str_json(it, last);	//string形式のjson
 	std::string err;
 	json = json11::Json::parse(str_json, err);//Jsonで使えるようにする
+	count_size = 0;
 	for (auto &item : json["audio"].array_items()) {
 		count_size++;//最大数を数える
 	}

--- a/Hide/BasicObject.cpp
+++ b/Hide/BasicObject.cpp
@@ -5,6 +5,7 @@
 //-----------------------------------
 
 BasicObject::BasicObject(Point point_) {
+	//shape = std::make_unique<Rendering>();
 	velocityX = 0;
 	velocityY = 0;
 	point.x = point_.x;

--- a/Hide/BasicObject.cpp
+++ b/Hide/BasicObject.cpp
@@ -5,7 +5,7 @@
 //-----------------------------------
 
 BasicObject::BasicObject(Point point_) {
-	//shape = std::make_unique<Rendering>();
+	shape = std::make_unique<Rendering>();
 	velocityX = 0;
 	velocityY = 0;
 	point.x = point_.x;

--- a/Hide/BasicObject.h
+++ b/Hide/BasicObject.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 #include"Point.h"
+#include "Rendering.h"
+#include <memory>
 
 //----------------------------------
 //基本となるクラス
@@ -14,6 +16,7 @@ public:
 	Point get_point();
 
 protected:
+	std::unique_ptr<Rendering> shape;	//姿・形
 	Point point;
 	//移動量
 	float velocityX;

--- a/Hide/BasicObject.h
+++ b/Hide/BasicObject.h
@@ -10,7 +10,7 @@
 class BasicObject {
 public:
 	//最低限の初期化
-	BasicObject(Point point);
+	BasicObject(Point);
 	//メソッド（関数）
 	virtual void update() = 0;
 	Point get_point();

--- a/Hide/BulletEnemy.cpp
+++ b/Hide/BulletEnemy.cpp
@@ -3,7 +3,7 @@
 
 BulletEnemy::BulletEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_) : Enemy(point_, physic_state_, enemy_state_)
 {
-	init_render("bullet");
+	shape->set("bullet");
 	switch (enemy_state_.anglestate) {
 	case AngleState::left:
 		angle = 1;

--- a/Hide/CoreTask.cpp
+++ b/Hide/CoreTask.cpp
@@ -4,15 +4,15 @@ GameTaskSystem *gts;
 
 CoreTask::CoreTask()
 {
-	graph = std::make_unique<GraphicResource>();
+	graph = std::shared_ptr<GraphicResource>();
 	scene = Scene::title;//–{“–‚Í^Cg‹
-	tts = std::make_unique<TitleTaskSystem>();
-	gts = std::make_unique<GameTaskSystem>();
-	ssts = std::make_unique<StageSelectTaskSystem>();
-	keyboard = std::make_unique<Keyboard>();
-	cts = std::make_unique<ClearTaskSystem>();
-	gots = std::make_unique<GameOverTaskSystem>();
-	audio = std::make_unique<Audio>();
+	tts = std::shared_ptr<TitleTaskSystem>();
+	gts = std::shared_ptr<GameTaskSystem>();
+	ssts = std::shared_ptr<StageSelectTaskSystem>();
+	keyboard = std::shared_ptr<Keyboard>();
+	cts = std::shared_ptr<ClearTaskSystem>();
+	gots = std::shared_ptr<GameOverTaskSystem>();
+	audio = std::shared_ptr<Audio>();
 }
 
 void CoreTask::update()

--- a/Hide/CoreTask.cpp
+++ b/Hide/CoreTask.cpp
@@ -1,18 +1,19 @@
 ﻿#include "CoreTask.h"
+#include "Rendering.h"
 
 GameTaskSystem *gts;
 
 CoreTask::CoreTask()
 {
-	graph = std::shared_ptr<GraphicResource>();
+	graph = std::make_shared<GraphicResource>();
 	scene = Scene::title;//–{“–‚Í^Cg‹
-	tts = std::shared_ptr<TitleTaskSystem>();
-	gts = std::shared_ptr<GameTaskSystem>();
-	ssts = std::shared_ptr<StageSelectTaskSystem>();
-	keyboard = std::shared_ptr<Keyboard>();
-	cts = std::shared_ptr<ClearTaskSystem>();
-	gots = std::shared_ptr<GameOverTaskSystem>();
-	audio = std::shared_ptr<Audio>();
+	tts = std::make_shared<TitleTaskSystem>();
+	gts = std::make_shared<GameTaskSystem>();
+	ssts = std::make_shared<StageSelectTaskSystem>();
+	keyboard = std::make_shared<Keyboard>();
+	cts = std::make_shared<ClearTaskSystem>();
+	gots = std::make_shared<GameOverTaskSystem>();
+	audio = std::make_shared<Audio>();
 }
 
 void CoreTask::update()
@@ -36,4 +37,11 @@ void CoreTask::update()
 		cts->update();
 		break;
 	}
+}
+
+void CoreTask::init()
+{
+	//静的メンバの初期化
+	Rendering::camera = gts->camera;
+	Rendering::resource = graph;
 }

--- a/Hide/CoreTask.h
+++ b/Hide/CoreTask.h
@@ -24,14 +24,14 @@ public:
 
 	CoreTask();
 	void update();
-	std::unique_ptr<GameTaskSystem> gts;
-	std::unique_ptr<TitleTaskSystem> tts;
-	std::unique_ptr<StageSelectTaskSystem> ssts;
-	std::unique_ptr<Keyboard> keyboard;
-	std::unique_ptr<ClearTaskSystem> cts;
-	std::unique_ptr<GraphicResource> graph;
-	std::unique_ptr<GameOverTaskSystem> gots;
-	std::unique_ptr<Audio> audio;
+	std::shared_ptr<GameTaskSystem> gts;
+	std::shared_ptr<TitleTaskSystem> tts;
+	std::shared_ptr<StageSelectTaskSystem> ssts;
+	std::shared_ptr<Keyboard> keyboard;
+	std::shared_ptr<ClearTaskSystem> cts;
+	std::shared_ptr<GraphicResource> graph;
+	std::shared_ptr<GameOverTaskSystem> gots;
+	std::shared_ptr<Audio> audio;
 };
 
 extern CoreTask *ct;

--- a/Hide/CoreTask.h
+++ b/Hide/CoreTask.h
@@ -24,6 +24,7 @@ public:
 
 	CoreTask();
 	void update();
+	void init();
 	std::shared_ptr<GameTaskSystem> gts;
 	std::shared_ptr<TitleTaskSystem> tts;
 	std::shared_ptr<StageSelectTaskSystem> ssts;

--- a/Hide/Effect.cpp
+++ b/Hide/Effect.cpp
@@ -1,6 +1,6 @@
 #include "Effect.h"
 
-Effect::Effect(Point point_) : Rendering(point_)
+Effect::Effect(Point point_) : BasicObject(point_)
 {
 }
 

--- a/Hide/Effect.h
+++ b/Hide/Effect.h
@@ -1,7 +1,7 @@
 #pragma once
-#include"Rendering.h"
+#include"BasicObject.h"
 
-class Effect : public Rendering {
+class Effect : public BasicObject {
 public:
 	Effect(Point);
 	//追加メソッドがあれば記述

--- a/Hide/Enemy.cpp
+++ b/Hide/Enemy.cpp
@@ -27,7 +27,7 @@ void Enemy::update()
 	move();
 	exercise();
 	attack();
-	draw();
+	shape->draw(point);
 }
 
 bool Enemy::damage(int d_)

--- a/Hide/FlyingEnemy.cpp
+++ b/Hide/FlyingEnemy.cpp
@@ -10,7 +10,7 @@ FlyingEnemy::FlyingEnemy(Point point_, PhysicState physic_state_, EnemyState ene
 	//必要か判断ができない初期化処理
 	flyingstate = FlyingState::down;
 	movecnt = 0;
-	init_render("flying");
+	shape->set("flying");
 }
 
 void FlyingEnemy::move()

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -12,7 +12,7 @@ GameTaskSystem::GameTaskSystem()
 
 	goal = std::make_unique<Goal>(g_point);
 	map = std::make_unique<Map>();
-	camera = std::make_unique<Camera>();
+	camera = std::make_shared<Camera>();
 	player = std::make_unique<Player>(p_point, p_physic_state, player_state);
 	enemys = std::make_shared<std::vector<std::unique_ptr<Enemy>>>();
 	enemy_transaction = std::make_shared<std::vector<std::unique_ptr<Enemy>>>();

--- a/Hide/GameTaskSystem.h
+++ b/Hide/GameTaskSystem.h
@@ -27,7 +27,7 @@ public:
 	std::unique_ptr<Player> player;
 	std::unique_ptr<Map> map;
 	std::unique_ptr<Goal> goal;
-	std::unique_ptr<Camera> camera;
+	std::shared_ptr<Camera> camera;
 	//☆
 	std::vector<NormalStar> normalstar;
 	//敵

--- a/Hide/Goal.cpp
+++ b/Hide/Goal.cpp
@@ -1,17 +1,16 @@
 ﻿#include"Goal.h"
 #include"CoreTask.h"
+#include "BasicObject.h"
 
-
-Goal::Goal(Point point_): Rendering(point_)
+Goal::Goal(Point point_):  BasicObject(point)
 {
-
 }
 
 void Goal::init()
 {
 	class Point g_point = { 30,510,30,30 };
 	point = g_point;
-	init_render("goal");
+	shape->set("goal");
 }
 
 void Goal::update()
@@ -30,7 +29,7 @@ bool Goal::hit(Point player_)
 	{
 		to_cleartask();
 	}
-	draw();
+	shape->draw(point);
 	return false;
 }
 

--- a/Hide/Goal.h
+++ b/Hide/Goal.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
-#include"Rendering.h"
+#include"BasicObject.h"
 
-class Goal : public Rendering{
+class Goal : public BasicObject{
 public:
 	Goal(Point point_);
 	void init();//Init_Renderを呼ぶ

--- a/Hide/GraphicResource.cpp
+++ b/Hide/GraphicResource.cpp
@@ -31,6 +31,7 @@ GraphicResource::GraphicResource()
 	std::string json_str(it, last);		//string形式のjson
 	std::string err;
 	json = json11::Json::parse(json_str,err);	//json11で利用できる形式に変換
+	count_of_graph = 0;
 	for (auto &item : json["graph"].array_items()) {
 		//画像の枚数を数える
 		count_of_graph++;

--- a/Hide/NormalStar.cpp
+++ b/Hide/NormalStar.cpp
@@ -12,7 +12,7 @@ NormalStar::NormalStar(Point point_, PhysicState physic_state_, StarState star_s
 {
 	velocityX = 20;
 	velocityY = 20;
-	init_render("star");
+	shape->set("star");
 }
 
 void NormalStar::update()
@@ -46,8 +46,7 @@ void NormalStar::update()
 		exercise();
 	}
 	attack();
-
-	draw();
+	shape->draw(point);
 	/*if (damage(1)) {
 		//ct->gts->normalstar->destroy();
 	}*/

--- a/Hide/Physic.cpp
+++ b/Hide/Physic.cpp
@@ -4,7 +4,7 @@
 //ï®óùâ^ìÆ
 //----------------------------------
 
-Physic::Physic(Point point, PhysicState physic_state) : Rendering(point)
+Physic::Physic(Point point, PhysicState physic_state) : BasicObject(point)
 {
 	gravity = physic_state.gravity;
 	repulsion = physic_state.repulsion;

--- a/Hide/Physic.h
+++ b/Hide/Physic.h
@@ -1,8 +1,8 @@
-#pragma once
-#include"Rendering.h"
+ï»¿#pragma once
+#include"BasicObject.h"
 
 //---------------------------------
-//•¨—‰^“®
+//ç‰©ç†é‹å‹•
 //---------------------------------
 
 struct PhysicState {
@@ -11,18 +11,18 @@ struct PhysicState {
 	int weight;
 };
 
-class Physic : public Rendering {
+class Physic : public BasicObject {
 public:
 	Physic(Point point,PhysicState physic_state);
-	//ƒƒ\ƒbƒh
-	virtual void exercise();//•¨—‰^“®‚ğs‚¤‚à‚Ì‚¾‚¯ˆ—‚ğs‚¤
+	//ãƒ¡ã‚½ãƒƒãƒ‰
+	virtual void exercise();//ç‰©ç†é‹å‹•ã‚’è¡Œã†ã‚‚ã®ã ã‘å‡¦ç†ã‚’è¡Œã†
 	/*virtual void rebound_X();
 	virtual void rebound_Y();*/
 protected:
-	//•Ï”
-	float gravity;//d—Í
-	float repulsion;//”½”­ŒW”
-	int weight;//d‚³(•¨‘Ì)
+	//å¤‰æ•°
+	float gravity;//é‡åŠ›
+	float repulsion;//åç™ºä¿‚æ•°
+	int weight;//é‡ã•(ç‰©ä½“)
 
 
 };

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -76,7 +76,7 @@ void Player::init()
 {
 	class Point p_point = { 500,30,30,30 };
 	point = p_point;
-	init_render("player");	//resource.jsonのnameが"player"のものをセットする
+	shape->set("player");//resource.jsonのnameが"player"のものをセットする
 }
 
 double Player::get_angle()
@@ -97,7 +97,7 @@ void Player::update()
 	//---------------------------------------
 	starmanager->update(angle, point.x);
 	playerinterface->update(hp,life);
-	draw();
+	shape->draw(point);
 	exercise();
 	DrawFormatString(0, 0, GetColor(255, 0, 0), "%d", point.x);//L
 	DrawFormatString(0, 50, GetColor(255, 0, 0), "%d", point.y);//T

--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -11,18 +11,19 @@ void Rendering::switch_anime()
 	}
 }
 
-void Rendering::draw(Point dist, int camera_x)
+void Rendering::draw(Point dist)
 {
-	DrawGraph(dist.x - camera_x , dist.y , *(handle_graph + cnt), 1);
+	DrawGraph(dist.x - camera->get_range().x , dist.y , *(handle_graph + cnt), 1);
 	current_rate++;	//毎フレーム増える
 	if (rate != 0 && rate % current_rate == 0) {
 		switch_anime();
 	}
 }
 
-Rendering::Rendering(std::shared_ptr<GraphicResource> _resource)
+Rendering::Rendering(std::shared_ptr<GraphicResource> _resource, std::shared_ptr<Camera> _camera)
 {
 	resource = _resource;
+	camera = _camera;
 }
 
 void Rendering::set(std::string scope)

--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -2,6 +2,9 @@
 #include"DxLib.h"
 #include "CoreTask.h"
 
+std::shared_ptr<GraphicResource> Rendering::resource;
+std::shared_ptr<Camera> Rendering::camera;
+
 void Rendering::switch_anime()
 {
 	cnt++;
@@ -18,12 +21,6 @@ void Rendering::draw(Point dist)
 	if (rate != 0 && rate % current_rate == 0) {
 		switch_anime();
 	}
-}
-
-Rendering::Rendering(std::shared_ptr<GraphicResource> _resource, std::shared_ptr<Camera> _camera)
-{
-	resource = _resource;
-	camera = _camera;
 }
 
 void Rendering::set(std::string scope)

--- a/Hide/Rendering.cpp
+++ b/Hide/Rendering.cpp
@@ -11,22 +11,23 @@ void Rendering::switch_anime()
 	}
 }
 
-void Rendering::draw()
+void Rendering::draw(Point dist, int camera_x)
 {
-	DrawGraph(point.x - ct->gts->camera->get_range().x , point.y , *(handle_graph + cnt), 1);
+	DrawGraph(dist.x - camera_x , dist.y , *(handle_graph + cnt), 1);
 	current_rate++;	//毎フレーム増える
 	if (rate != 0 && rate % current_rate == 0) {
 		switch_anime();
 	}
 }
 
-Rendering::Rendering(Point point) : BasicObject(point)
+Rendering::Rendering(std::shared_ptr<GraphicResource> _resource)
 {
+	resource = _resource;
 }
 
-void Rendering::init_render(std::string scope)
+void Rendering::set(std::string scope)
 {
-	GraphicObject obj = ct->graph->get(scope);
+	GraphicObject obj = resource->get(scope);	//GraphicObjectを共有するように改善予定
 	if (obj.exist == false) throw std::runtime_error("The scope is not exist.");
 	cnt = 0;
 	max = obj.max;

--- a/Hide/Rendering.h
+++ b/Hide/Rendering.h
@@ -3,9 +3,11 @@
 #include "GraphicResource.h"
 #include "Camera.h"
 
+
 class Rendering {
 private:
-	static std::shared_ptr<GraphicResource> resource;
+	friend class CoreTask;
+	static  std::shared_ptr<GraphicResource> resource;
 	static std::shared_ptr<Camera> camera;
 	std::shared_ptr<GraphicObject> object;
 
@@ -20,8 +22,9 @@ private:
 	void switch_anime();
 
 public:
+
 	Rendering() {};
-	Rendering(std::shared_ptr<GraphicResource>, std::shared_ptr<Camera>);
 	void draw(Point);
 	void set(std::string);
 };
+

--- a/Hide/Rendering.h
+++ b/Hide/Rendering.h
@@ -1,10 +1,12 @@
 ﻿#pragma once
 #include <memory>
 #include "GraphicResource.h"
+#include "Camera.h"
 
 class Rendering {
 private:
 	static std::shared_ptr<GraphicResource> resource;
+	static std::shared_ptr<Camera> camera;
 	std::shared_ptr<GraphicObject> object;
 
 	//下記objectに置き換え予定
@@ -19,7 +21,7 @@ private:
 
 public:
 	Rendering() {};
-	Rendering(std::shared_ptr<GraphicResource>);
-	void draw(Point, int camera_x);
+	Rendering(std::shared_ptr<GraphicResource>, std::shared_ptr<Camera>);
+	void draw(Point);
 	void set(std::string);
 };

--- a/Hide/Rendering.h
+++ b/Hide/Rendering.h
@@ -1,9 +1,13 @@
 ﻿#pragma once
-#include"BasicObject.h"
+#include <memory>
 #include "GraphicResource.h"
 
-class Rendering : public BasicObject {
+class Rendering {
 private:
+	static std::shared_ptr<GraphicResource> resource;
+	std::shared_ptr<GraphicObject> object;
+
+	//下記objectに置き換え予定
 	int max;	//最大枚数
 	int rate; //切替速度
 	int current_rate;
@@ -13,13 +17,9 @@ private:
 
 	void switch_anime();
 
-protected:
-
-	//アニメーションを切り替える
-	void init_render(std::string scope);
-
-	void draw();
-
 public:
-	Rendering(Point point);
+	Rendering() {};
+	Rendering(std::shared_ptr<GraphicResource>);
+	void draw(Point, int camera_x);
+	void set(std::string);
 };

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -7,7 +7,7 @@ ThrowingEnemy::ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState
 	anglestate = AngleState::right;
 	x = -1;
 	cnt = 0;
-	init_render("throwing");
+	shape->set("throwing");
 }
 
 void ThrowingEnemy::move()

--- a/Hide/WalkingEnemy.cpp
+++ b/Hide/WalkingEnemy.cpp
@@ -6,7 +6,7 @@ WalkingEnemy::WalkingEnemy(Point point_, PhysicState physic_state_, EnemyState e
 	//必要か判断ができない初期化処理
 	anglestate = AngleState::right;
 	walkingstate = WalkingState::walk;
-	init_render("walking");
+	shape->set("walking");
 }
 
 void WalkingEnemy::move()

--- a/Hide/main.cpp
+++ b/Hide/main.cpp
@@ -21,7 +21,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	if (DxLib_Init() == -1) { return -1; };
 	
 	SetMainWindowText("Stern");
-	Rendering init(ct->graph);	//オーバーロードされたコンストラクタによりクラス変数を初期化する
+	Rendering init(ct->graph, ct->gts->camera);	//オーバーロードされたコンストラクタによりクラス変数を初期化する
 
 	ct = new CoreTask;
 	//音

--- a/Hide/main.cpp
+++ b/Hide/main.cpp
@@ -21,7 +21,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	if (DxLib_Init() == -1) { return -1; };
 	
 	SetMainWindowText("Stern");
-
+	Rendering init(ct->graph);	//オーバーロードされたコンストラクタによりクラス変数を初期化する
 
 	ct = new CoreTask;
 	//音

--- a/Hide/main.cpp
+++ b/Hide/main.cpp
@@ -21,9 +21,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	if (DxLib_Init() == -1) { return -1; };
 	
 	SetMainWindowText("Stern");
-	Rendering init(ct->graph, ct->gts->camera);	//オーバーロードされたコンストラクタによりクラス変数を初期化する
 
 	ct = new CoreTask;
+	ct->init();
 	//音
 	ct->audio->load("action");
 	//画像


### PR DESCRIPTION
BasicObjectを継承したRenderingクラスをBasicObjectのコンポジションに変更。
変更によりRenderingクラスの振る舞いを変えずに内部の変更をすることが容易になった。
実行による動作確認済み。

## 初期化
### 従来
init_render(string)

### 最新
shape->set(string)


## 描画
### 従来
draw()

### 最新
shape->draw(Point)