### PR TITLE
数値をいじるだけの細かい修正

### DIFF
--- a/Hide/BulletEnemy.cpp
+++ b/Hide/BulletEnemy.cpp
@@ -6,10 +6,10 @@ BulletEnemy::BulletEnemy(Point point_, PhysicState physic_state_, EnemyState ene
 	shape->set("bullet");
 	switch (enemy_state_.anglestate) {
 	case AngleState::left:
-		angle = 1;
+		angle = 2;
 		break;
 	case AngleState::right:
-		angle = -1;
+		angle = -2;
 		break;
 	}
 }

--- a/Hide/Camera.cpp
+++ b/Hide/Camera.cpp
@@ -20,8 +20,8 @@ void Camera::update()
 	//カメラの位置を再調整
 	{
 		//プレイヤを画面の何処に置くか(今回は画面中央)
-		int px = 600 / 2;
-		int py = 600 / 2;
+		int px = System::width / 2;
+		int py = System::height / 2;
 		//プレイヤを画面中央の置いた時のカメラの左上座標を求める
 		int cpx = ct->gts->player->get_point().x - px+ ct->gts->player->get_point().w/2;//player.wの半分だけたす
 		int cpy = ct->gts->player->get_point().y - py + ct->gts->player->get_point().h / 2;

--- a/Hide/GameTaskSystem.cpp
+++ b/Hide/GameTaskSystem.cpp
@@ -73,6 +73,7 @@ void GameTaskSystem::update()
 	for (auto itr = enemys->begin(); itr != enemys->end(); ++itr) {
 		(*itr)->update();
 	}
+
 	//--------------------------------
 	//アイテム-----------------------------
 	for (auto itr = item->begin(); itr != item->end(); ++itr) {

--- a/Hide/Hide.vcxproj
+++ b/Hide/Hide.vcxproj
@@ -191,6 +191,8 @@
     <ClInclude Include="GameOverTaskUI.h" />
     <ClInclude Include="Goal.h" />
     <ClInclude Include="GraphicResource.h" />
+    <ClInclude Include="SelectTaskConfig.h" />
+    <ClInclude Include="StarConfig.h" />
     <ClInclude Include="Item.h" />
     <ClInclude Include="json11.hpp" />
     <ClInclude Include="PauseTaskSystem.h" />
@@ -227,6 +229,7 @@
     <ClInclude Include="Star.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="ThrowingEnemy.h" />
+    <ClInclude Include="ThrowingEnemyConfig.h" />
     <ClInclude Include="TitleUI.h" />
     <ClInclude Include="TitleTaskSystem.h" />
     <ClInclude Include="WalkingEnemy.h" />

--- a/Hide/Hide.vcxproj.filters
+++ b/Hide/Hide.vcxproj.filters
@@ -402,9 +402,6 @@
     <ClInclude Include="SpawnEnemy.h">
       <Filter>controllers\spawn\enemy</Filter>
     </ClInclude>
-    <ClInclude Include="SpawnItem.h">
-      <Filter>controllers\spawn\item</Filter>
-    </ClInclude>
     <ClInclude Include="PauseTaskSystem.h">
       <Filter>views\pause</Filter>
     </ClInclude>
@@ -459,14 +456,20 @@
     <ClInclude Include="screen_helper.h">
       <Filter>helper\screen_helper</Filter>
     </ClInclude>
-    <ClInclude Include="FlyingEnemyConfig.h">
-      <Filter>config</Filter>
-    </ClInclude>
-    <ClInclude Include="WalkingEnemyConfig.h">
-      <Filter>config</Filter>
-    </ClInclude>
     <ClInclude Include="Scene.h">
       <Filter>interfaces\Scene</Filter>
+    </ClInclude>
+    <ClInclude Include="SpawnItem.h">
+      <Filter>controllers\spawn\super</Filter>
+    </ClInclude>
+    <ClInclude Include="StarConfig.h">
+      <Filter>config</Filter>
+    </ClInclude>
+    <ClInclude Include="SelectTaskConfig.h">
+      <Filter>config</Filter>
+    </ClInclude>
+    <ClInclude Include="ThrowingEnemyConfig.h">
+      <Filter>config</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Hide/NormalStar.cpp
+++ b/Hide/NormalStar.cpp
@@ -1,6 +1,7 @@
 ﻿#include"NormalStar.h"
 #include"DxLib.h"
 #include"CoreTask.h"
+#include"environments.h"
 
 //--------------------------------
 //
@@ -33,7 +34,7 @@ void NormalStar::update()
 			gravitypoint = itr->gravitypoint;
 		}
 		if (((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) * ((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) +//gravitystarとの距離を測って90000以内なら引き寄せられる
-			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=360000) {//90000は大体今の画面内の範囲
+			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=environment::star_inhale_able) {//90000は大体今の画面内の範囲
 			inhale();
 		}
 	}

--- a/Hide/NormalStar.cpp
+++ b/Hide/NormalStar.cpp
@@ -1,7 +1,7 @@
 ﻿#include"NormalStar.h"
 #include"DxLib.h"
 #include"CoreTask.h"
-#include"environments.h"
+#include"StarConfig.h"
 
 //--------------------------------
 //
@@ -11,7 +11,7 @@ NormalStar::NormalStar(Point point_, PhysicState physic_state_, StarState star_s
 {
 	point = point_;
 	shape->set("star");
-	life = 180;
+	life = STAR_LIFE;
 	gravitypoint = { 0,0,0,0 };
 }
 
@@ -33,13 +33,13 @@ void NormalStar::update()
 		for (auto itr = ct->gts->gravityStar.begin(); itr != ct->gts->gravityStar.end(); ++itr) {
 			gravitypoint = itr->gravitypoint;
 		}
-		if (((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) * ((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) +//gravitystarとの距離を測って90000以内なら引き寄せられる
-			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=environment::star_inhale_able) {//90000は大体今の画面内の範囲
+		if (((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) * ((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) +
+			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=STAR_INHALE_ABLE) {
 			inhale();
 		}
 	}
 	attack();
-	if (life > 60) {
+	if (life > STAR_LIFE/3) {
 		shape->draw(point);
 	}
 	else if (life % 4 >= 2) {

--- a/Hide/NormalStar.cpp
+++ b/Hide/NormalStar.cpp
@@ -33,7 +33,7 @@ void NormalStar::update()
 			gravitypoint = itr->gravitypoint;
 		}
 		if (((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) * ((gravitypoint.x + gravitypoint.w / 2) - (point.x + point.w/2)) +//gravitystarとの距離を測って90000以内なら引き寄せられる
-			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=90000) {//90000は大体今の画面内の範囲
+			((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) * ((gravitypoint.y + gravitypoint.h / 2) - (point.y + point.h/2)) <=360000) {//90000は大体今の画面内の範囲
 			inhale();
 		}
 	}

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -53,7 +53,7 @@ void Player::StarManager::update(double ang, int x_)
 	draw(ang, x_);
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_Z)) {
-			starmanagercoolCnt = environment::star_cooltime;   //クールタイム60フレーム
+			starmanagercoolCnt = STAR_COOLTIME;   //クールタイム60フレーム
 			class Point point = { x_,Map::get_camera().y,32,32 };
 			struct PhysicState physic_state = { 1 };//	float gravity;
 			struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
@@ -66,7 +66,7 @@ void Player::StarManager::update(double ang, int x_)
 
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_V)) {
-			starmanagercoolCnt = environment::star_cooltime;   //クールタイム60フレーム
+			starmanagercoolCnt = STAR_COOLTIME;   //クールタイム60フレーム
 			ct->gts->gravityStar.clear();
 			class Point point = { x_ ,Map::get_camera().y,32,32 };
 			struct PhysicState physic_state = { 1 };//	float gravity;
@@ -124,10 +124,10 @@ void Player::update()
 	//仮の移動とカーソル角度調整-------------
 	move();
 	if (Keyboard::key_press(KEY_INPUT_Q)) {
-		angle += environment::cursol_speed;
+		angle += CURSOL_TURN_SPEED;
 	}
 	if (Keyboard::key_press(KEY_INPUT_E)) {
-		angle -= environment::cursol_speed;
+		angle -= CURSOL_TURN_SPEED;
 	}
 	//---------------------------------------
 	starmanager->update(angle, point.x);
@@ -146,7 +146,7 @@ void Player::update()
 bool Player::damage()
 {
 	if (invincible <= 0) {
-		invincible = environment::player_invincible;
+		invincible = PLAYER_INVINCIBLE;
 		hp -= 1;
 		if (hp <= 0) {
 			return true;

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -4,6 +4,7 @@
 #include"Keyboard.h"
 #include "PlayerConfig.h"
 #include"System.h"
+#include"environments.h"
 
 //----------------------------------
 //プレイヤー
@@ -52,7 +53,7 @@ void Player::StarManager::update(double ang, int x_)
 	draw(ang, x_);
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_Z)) {
-			starmanagercoolCnt = 60;   //クールタイム60フレーム
+			starmanagercoolCnt = environment::star_cooltime;   //クールタイム60フレーム
 			class Point point = { x_,Map::get_camera().y,32,32 };
 			struct PhysicState physic_state = { 1 };//	float gravity;
 			struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
@@ -65,7 +66,7 @@ void Player::StarManager::update(double ang, int x_)
 
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_V)) {
-			starmanagercoolCnt = 60;   //クールタイム60フレーム
+			starmanagercoolCnt = environment::star_cooltime;   //クールタイム60フレーム
 			ct->gts->gravityStar.clear();
 			class Point point = { x_ ,Map::get_camera().y,32,32 };
 			struct PhysicState physic_state = { 1 };//	float gravity;
@@ -123,10 +124,10 @@ void Player::update()
 	//仮の移動とカーソル角度調整-------------
 	move();
 	if (Keyboard::key_press(KEY_INPUT_Q)) {
-		angle += 0.05;
+		angle += environment::cursol_speed;
 	}
 	if (Keyboard::key_press(KEY_INPUT_E)) {
-		angle -= 0.05;
+		angle -= environment::cursol_speed;
 	}
 	//---------------------------------------
 	starmanager->update(angle, point.x);
@@ -145,7 +146,7 @@ void Player::update()
 bool Player::damage()
 {
 	if (invincible <= 0) {
-		invincible = 180;
+		invincible = environment::player_invincible;
 		hp -= 1;
 		if (hp <= 0) {
 			return true;

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -3,6 +3,7 @@
 #include"CoreTask.h"
 #include"Keyboard.h"
 #include "PlayerConfig.h"
+#include"System.h"
 
 //----------------------------------
 //プレイヤー
@@ -18,8 +19,8 @@ Player::PlayerInterface::PlayerInterface()
 void Player::PlayerInterface::draw()
 {
 	//残機
-	DrawGraph(500, 0, lifegraph, FALSE);
-	DrawFormatString(540, 0, GetColor(255, 255, 255), " × %d",life);
+	DrawGraph(System::width-100, 0, lifegraph, FALSE);
+	DrawFormatString(System::width - 60, 0, GetColor(255, 255, 255), " × %d",life);
 	//HP
 	for (int i = 0; i < 3; ++i) {
 		DrawGraph(40 * i, 0, hpfreamgraph, FALSE);
@@ -51,7 +52,7 @@ void Player::StarManager::update(double ang, int x_)
 	draw(ang, x_);
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_Z)) {
-			starmanagercoolCnt = 180;   //クールタイム180フレーム
+			starmanagercoolCnt = 60;   //クールタイム60フレーム
 			class Point point = { x_,Map::get_camera().y,32,32 };
 			struct PhysicState physic_state = { 1 };//	float gravity;
 			struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
@@ -61,17 +62,21 @@ void Player::StarManager::update(double ang, int x_)
 			//Point point_, PhysicState physic_state_, StarState star_state
 		}
 	}
+
+	if (starmanagercoolCnt <= 0) {
+		if (Keyboard::key_down(KEY_INPUT_V)) {
+			starmanagercoolCnt = 60;   //クールタイム60フレーム
+			ct->gts->gravityStar.clear();
+			class Point point = { x_ ,Map::get_camera().y,32,32 };
+			struct PhysicState physic_state = { 1 };//	float gravity;
+			struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
+
+			ct->gts->gravityStar.push_back(GravityStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
+
+		}
+	}
 	if (starmanagercoolCnt > 0) {
 		starmanagercoolCnt--;
-	}
-	if (Keyboard::key_down(KEY_INPUT_V)) {
-		ct->gts->gravityStar.clear();
-		class Point point = { x_ ,Map::get_camera().y,32,32 };
-		struct PhysicState physic_state = { 1 };//	float gravity;
-		struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
-
-		ct->gts->gravityStar.push_back(GravityStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
-
 	}
 }
 

--- a/Hide/Player.cpp
+++ b/Hide/Player.cpp
@@ -55,51 +55,52 @@ void Player::StarManager::update(double ang, int x_)
 	if (starmanagercoolCnt <= 0) {
 		if (Keyboard::key_down(KEY_INPUT_Z)) {
 			starmanagercoolCnt = STAR_COOLTIME;   //クールタイム60フレーム
-		Point prestarpoint{ x_, Map::get_camera().y, 32, 32 };
-		if (!(ct->gts->map->get_bottom(prestarpoint) ||
-			ct->gts->map->get_left(prestarpoint) ||
-			ct->gts->map->get_right(prestarpoint) ||
-			ct->gts->map->get_top(prestarpoint))) {
-			if (starmanagercoolCnt <= 0) {
-				starmanagercoolCnt = 180;   //クールタイム180フレーム
-				class Point point = { x_,Map::get_camera().y,32,32 };
-				struct PhysicState physic_state = { 1 };//	float gravity;
-				struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
+			Point prestarpoint{ x_, Map::get_camera().y, 32, 32 };
+			if (!(ct->gts->map->get_bottom(prestarpoint) ||
+				ct->gts->map->get_left(prestarpoint) ||
+				ct->gts->map->get_right(prestarpoint) ||
+				ct->gts->map->get_top(prestarpoint))) {
+				if (starmanagercoolCnt <= 0) {
+					starmanagercoolCnt = 180;   //クールタイム180フレーム
+					class Point point = { x_,Map::get_camera().y,32,32 };
+					struct PhysicState physic_state = { 1 };//	float gravity;
+					struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
 
-				ct->gts->normalstar.push_back(NormalStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
-				//ノーマルスター
-				//Point point_, PhysicState physic_state_, StarState star_state
+					ct->gts->normalstar.push_back(NormalStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
+					//ノーマルスター
+					//Point point_, PhysicState physic_state_, StarState star_state
+				}
 			}
 		}
-	}
-      	else {
-		//キャンセル音をだす　
-	}
-
-	if (starmanagercoolCnt <= 0) {
-		if (Keyboard::key_down(KEY_INPUT_V)) {
-			starmanagercoolCnt = STAR_COOLTIME;   //クールタイム60フレーム
-		Point prestarpoint{ x_, Map::get_camera().y, 32, 32 };
-		if (!(ct->gts->map->get_bottom(prestarpoint) ||
-			ct->gts->map->get_left(prestarpoint) ||
-			ct->gts->map->get_right(prestarpoint) ||
-			ct->gts->map->get_top(prestarpoint))) {
-
-			ct->gts->gravityStar.clear();
-			class Point point = { x_ ,Map::get_camera().y,32,32 };
-			struct PhysicState physic_state = { 1 };//	float gravity;
-			struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
-
-			ct->gts->gravityStar.push_back(GravityStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
-
-
-		}
-	}
-	if (starmanagercoolCnt > 0) {
-		starmanagercoolCnt--;
-
+		else {
+			//キャンセル音をだす　
 		}
 
+		if (starmanagercoolCnt <= 0) {
+			if (Keyboard::key_down(KEY_INPUT_V)) {
+				starmanagercoolCnt = STAR_COOLTIME;   //クールタイム60フレーム
+				Point prestarpoint{ x_, Map::get_camera().y, 32, 32 };
+				if (!(ct->gts->map->get_bottom(prestarpoint) ||
+					ct->gts->map->get_left(prestarpoint) ||
+					ct->gts->map->get_right(prestarpoint) ||
+					ct->gts->map->get_top(prestarpoint))) {
+
+					ct->gts->gravityStar.clear();
+					class Point point = { x_ ,Map::get_camera().y,32,32 };
+					struct PhysicState physic_state = { 1 };//	float gravity;
+					struct StarState star_state = { 10,10,10,50,ang };//	int bright, int radius, int power, int life, double angle;
+
+					ct->gts->gravityStar.push_back(GravityStar{ point,physic_state,star_state });	//新規インスタンスを生成して最後尾へ登録する
+
+
+				}
+			}
+			if (starmanagercoolCnt > 0) {
+				starmanagercoolCnt--;
+
+			}
+
+		}
 	}
 }
 

--- a/Hide/PlayerConfig.h
+++ b/Hide/PlayerConfig.h
@@ -3,3 +3,7 @@
 #define PLAYER_MAX_JUMP 18	//playerの最大ジャンプ力
 #define PLAYER_SPEED 6
 #define PLAYER_MAX_SPEED 9
+#define PLAYER_INVINCIBLE 120
+//Starmanager-----------------------------
+#define CURSOL_TURN_SPEED 0.05f
+#define STAR_COOLTIME 30

--- a/Hide/RecoveryItem.cpp
+++ b/Hide/RecoveryItem.cpp
@@ -8,6 +8,7 @@ RecoveryItem::RecoveryItem(Point point_) : Item(point_)
 
 void RecoveryItem::affect()
 {
+	if(player->hp<2)
 	player->hp++;
 	//回復
 }

--- a/Hide/SelectTaskConfig.h
+++ b/Hide/SelectTaskConfig.h
@@ -1,0 +1,3 @@
+#pragma once
+#define MAX_STAGE 4
+#define CHARA_VELOCITY 5

--- a/Hide/StageSelectTaskMass.cpp
+++ b/Hide/StageSelectTaskMass.cpp
@@ -1,10 +1,11 @@
 ﻿#include "StageSelectTaskMass.h"
 #include"DxLib.h"
+#include"SelectTaskConfig.h"
 #include"System.h"
 
 StageSelectTaskMass::StageSelectTaskMass()
 {
-	mass = 4;
+	mass = MAX_STAGE;
 	//x = System::width / 4;//画像を描画する始点(4マスの中の一番左のマスの左座標)
 	y = 200;
 	graph = LoadGraph("img/stageselect/mass.png");
@@ -43,7 +44,7 @@ int StageSelectTaskMass::get_massY()
 
 int StageSelectTaskMass::get_massline()
 {
-	return System::width / 4;
+	return System::width / MAX_STAGE;
 }
 
 

--- a/Hide/StageSelectTaskMass.h
+++ b/Hide/StageSelectTaskMass.h
@@ -1,11 +1,11 @@
 ﻿#pragma once
-
+#include "SelectTaskConfig.h"
 class StageSelectTaskMass {
 private:
 	int x;
 	int y;//表示する高さ
 	int mass;
-	int mass_x[4];
+	int mass_x[MAX_STAGE];
 	//画像
 	int graph;
 public:

--- a/Hide/StageSelectTaskSystem.cpp
+++ b/Hide/StageSelectTaskSystem.cpp
@@ -5,10 +5,11 @@
 #include"screenhelper_config.h"
 #include "Keyboard.h"
 #include "Scene.h"
+#include"SelectTaskConfig.h"
 
 //静的定義----------------------------------------------------------------
 int StageSelectTaskSystem::stage;//ステージ識別番号
-bool StageSelectTaskSystem::state[4];//クリアフラグ（ステージ総数によって変える）
+bool StageSelectTaskSystem::state[MAX_STAGE];//クリアフラグ（ステージ総数によって変える）
 
 bool StageSelectTaskSystem::feed_flag;
 

--- a/Hide/StageSelectTaskSystem.h
+++ b/Hide/StageSelectTaskSystem.h
@@ -5,11 +5,12 @@
 #include"StageselectTaskTextBox.h"
 #include"SpawnEnemy.h"//敵生成をステージ選択直後に行うため
 #include"SpawnItem.h"
+#include"SelectTaskConfig.h"
 
 class StageSelectTaskSystem {
 protected:
 	static int stage;//ステージ識別番号
-	static bool state[4];//クリアフラグ（ステージ総数によって変える）
+	static bool state[MAX_STAGE];//クリアフラグ（ステージ総数によって変える）
 private:
 	static bool feed_flag;
 

--- a/Hide/StageselectChara.cpp
+++ b/Hide/StageselectChara.cpp
@@ -48,12 +48,12 @@ void StageSelectChara::select_stage(int& stage_, bool deg, int massline)
 void StageSelectChara::move()
 {
 	if (velocityX > 0) {
-		point.x += 2;
-		velocityX -= 2;
+		point.x += 5;
+		velocityX -= 5;
 	}
 	if (velocityX < 0) {
-		point.x -= 2;
-		velocityX += 2;
+		point.x -= 5;
+		velocityX += 5;
 	}
 }
 

--- a/Hide/StageselectChara.cpp
+++ b/Hide/StageselectChara.cpp
@@ -3,6 +3,7 @@
 #include"Dxlib.h"
 #include"System.h"
 #include "Keyboard.h"
+#include"environments.h"
 
 StageSelectChara::StageSelectChara(Point point_)
 {
@@ -48,12 +49,12 @@ void StageSelectChara::select_stage(int& stage_, bool deg, int massline)
 void StageSelectChara::move()
 {
 	if (velocityX > 0) {
-		point.x += 5;
-		velocityX -= 5;
+		point.x += environment::select_chara_velocity;
+		velocityX -= environment::select_chara_velocity;
 	}
 	if (velocityX < 0) {
-		point.x -= 5;
-		velocityX += 5;
+		point.x -= environment::select_chara_velocity;
+		velocityX += environment::select_chara_velocity;
 	}
 }
 

--- a/Hide/StageselectChara.cpp
+++ b/Hide/StageselectChara.cpp
@@ -3,7 +3,7 @@
 #include"Dxlib.h"
 #include"System.h"
 #include "Keyboard.h"
-#include"environments.h"
+#include"SelectTaskConfig.h"
 
 StageSelectChara::StageSelectChara(Point point_)
 {
@@ -34,7 +34,7 @@ void StageSelectChara::draw()
 void StageSelectChara::select_stage(int& stage_, bool deg, int massline)
 {
 	if (!deg) {
-		if (Keyboard::key_down(KEY_INPUT_RIGHT) && stage_ < 4 && velocityX == 0) {
+		if (Keyboard::key_down(KEY_INPUT_RIGHT) && stage_ < MAX_STAGE && velocityX == 0) {
 			velocityX = massline;
 			stage_++;
 		}
@@ -49,12 +49,12 @@ void StageSelectChara::select_stage(int& stage_, bool deg, int massline)
 void StageSelectChara::move()
 {
 	if (velocityX > 0) {
-		point.x += environment::select_chara_velocity;
-		velocityX -= environment::select_chara_velocity;
+		point.x += CHARA_VELOCITY;
+		velocityX -= CHARA_VELOCITY;
 	}
 	if (velocityX < 0) {
-		point.x -= environment::select_chara_velocity;
-		velocityX += environment::select_chara_velocity;
+		point.x -= CHARA_VELOCITY;
+		velocityX += CHARA_VELOCITY;
 	}
 }
 

--- a/Hide/StarConfig.h
+++ b/Hide/StarConfig.h
@@ -1,0 +1,3 @@
+#pragma once
+#define STAR_INHALE_ABLE 350000
+#define STAR_LIFE 180

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -20,7 +20,7 @@ void ThrowingEnemy::move()
 
 void ThrowingEnemy::appear_shot()
 {
-	if (cnt > 180) {
+	if (cnt > 300) {
 		class Point b_point = { point.x,point.y + 32,32,32 };
 		struct PhysicState physic_state = { 0};//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -1,6 +1,6 @@
 ﻿#include "ThrowingEnemy.h"
 #include "CoreTask.h"
-#include"environments.h"
+#include "ThrowingEnemyConfig.h"
 
 ThrowingEnemy::ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_) : Enemy(point_, physic_state_, enemy_state_)
 {
@@ -21,7 +21,7 @@ void ThrowingEnemy::move()
 
 void ThrowingEnemy::appear_shot()
 {
-	if (cnt > environment::throwing_interbal) {
+	if (cnt > THROW_INTERBAL) {
 		class Point b_point = { point.x,point.y + 32,32,32 };
 		struct PhysicState physic_state = { 0};//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;

--- a/Hide/ThrowingEnemy.cpp
+++ b/Hide/ThrowingEnemy.cpp
@@ -1,5 +1,6 @@
 ﻿#include "ThrowingEnemy.h"
 #include "CoreTask.h"
+#include"environments.h"
 
 ThrowingEnemy::ThrowingEnemy(Point point_, PhysicState physic_state_, EnemyState enemy_state_) : Enemy(point_, physic_state_, enemy_state_)
 {
@@ -20,7 +21,7 @@ void ThrowingEnemy::move()
 
 void ThrowingEnemy::appear_shot()
 {
-	if (cnt > 300) {
+	if (cnt > environment::throwing_interbal) {
 		class Point b_point = { point.x,point.y + 32,32,32 };
 		struct PhysicState physic_state = { 0};//	float gravity; float repulsion;int weight;
 		struct EnemyState Enemy_state = { 1,1,anglestate };//	int life, int damage, int power, int life, double angle;

--- a/Hide/ThrowingEnemyConfig.h
+++ b/Hide/ThrowingEnemyConfig.h
@@ -1,0 +1,2 @@
+#pragma once
+#define THROW_INTERBAL 300

--- a/Hide/development.cpp
+++ b/Hide/development.cpp
@@ -1,10 +1,1 @@
 ﻿//開発環境の固有の設定
-#include "environments.h"
-namespace environment {
-	int player_invincible = 120;
-	int star_cooltime = 60;
-	int star_inhale_able = 350000;
-	float cursol_speed = 0.05f;
-	int select_chara_velocity = 5;
-	int throwing_interbal = 300;
-}

--- a/Hide/development.cpp
+++ b/Hide/development.cpp
@@ -1,1 +1,10 @@
 ﻿//開発環境の固有の設定
+#include "environments.h"
+namespace environment {
+	int player_invincible = 120;
+	int star_cooltime = 60;
+	int star_inhale_able = 350000;
+	float cursol_speed = 0.05f;
+	int select_chara_velocity = 5;
+	int throwing_interbal = 300;
+}

--- a/Hide/environments.h
+++ b/Hide/environments.h
@@ -1,1 +1,9 @@
 ﻿#pragma once
+namespace environment {
+	extern int star_cooltime;
+	extern int star_inhale_able;
+	extern int player_invincible;
+	extern float cursol_speed;
+	extern int select_chara_velocity;
+	extern int throwing_interbal;
+}

--- a/Hide/environments.h
+++ b/Hide/environments.h
@@ -1,9 +1,1 @@
 ﻿#pragma once
-namespace environment {
-	extern int star_cooltime;
-	extern int star_inhale_able;
-	extern int player_invincible;
-	extern float cursol_speed;
-	extern int select_chara_velocity;
-	extern int throwing_interbal;
-}


### PR DESCRIPTION
タネを早くした
カメラの中央を修正
星の引き寄せられる距離を４倍に
残基表示を右上に
グラヴィティスターのクールタイムを実装
星を出すクールタイムを６０フレームに
最大値を超えてhpが回復するのを修正
ステージセレクトのキャラクターを高速化
タネを出す間隔を長くした